### PR TITLE
Make router.js optional; add router blueprint (fixes issue #55)

### DIFF
--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -81,6 +81,8 @@ export default Em.Controller.extend({
     addFile (type) {
       var template = '';
       var filePath = '';
+      var canChangePath = true;
+
       if(type==='component-hbs') {
         template = '<b class="foo">{{yield}}</b>';
         filePath = 'templates/components/foo-component.hbs';
@@ -93,12 +95,23 @@ export default Em.Controller.extend({
         template = 'export default Ember.Controller.extend({\n});';
         filePath = 'controllers/foo.js';
       }
+      else if(type==='route') {
+        template = 'export default Ember.Route.extend({\n});';
+        filePath = 'routes/foo.js';
+      }
       else if(type==='template') {
         template = '<b>Hi!</b>';
         filePath = 'templates/foo.hbs';
       }
+      else if(type==='router') {
+        template = 'import Ember from \'ember\';\nvar Router = Ember.Router.extend({\n  location: \'none\'\n});\n\nRouter.map(function() {\n});\n\nexport default Router;\n';
+        filePath = 'router.js';
+        canChangePath = false;
+      }
 
-      filePath = prompt('File path', filePath);
+      if (canChangePath) {
+        filePath = prompt('File path', filePath);
+      }
 
       if (filePath) {
         if(this.get('model.files').findBy('filePath', filePath)) {

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -10,11 +10,13 @@
         <li class="dropdown-submenu">
           <a tabindex="-1" href="#">Add...</a>
           <ul class="dropdown-menu">
+            <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
             <li><a {{action 'addFile' 'component-hbs'}}>Component (hbs)</a></li>
             <li><a {{action 'addFile' 'component-js'}}>Component (js)</a></li>
             <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
+            <li><a {{action 'addFile' 'route'}}>Route</a></li>
             <li><a {{action 'addFile' 'template'}}>Template</a></li>
-            <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
+            <li><a {{action 'addFile' 'router'}}>Router</a></li>
           </ul>
         </li>
         {{#if activeEditor}}

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -48,6 +48,7 @@ export default Em.Service.extend({
       // Add router
       if (!gist.get('files').findBy('nameWithModule', 'demo-app/router')) {
         out.push(this.compileJs(blueprints.router, 'demo-app/router'));
+        console.error('Missing a router.js See issue https://github.com/ember-cli/ember-twiddle/issues/55#issuecomment-121724317');
       }
       out.push(this.compileJs('import Router from \'demo-app/router\';\nRouter.reopen({\n  updateUrlBar: Ember.on(\'didTransition\', function() {\n    window.parent.demoAppUrl = this.get(\'url\');\n    window.parent.updateDemoAppUrl();\n  })\n});\nexport default {name: \'router\',\n initialize: function() {}\n};\n', 'demo-app/initializers/router'));
 

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -42,9 +42,16 @@ export default Em.Service.extend({
 
       if (errors.length) {return reject(errors);}
 
-      // Add app, config
+      // Add app
       out.push(this.compileJs(blueprints.app, 'demo-app/app'));
+
+      // Add router
+      if (!gist.get('files').findBy('nameWithModule', 'demo-app/router')) {
+        out.push(this.compileJs(blueprints.router, 'demo-app/router'));
+      }
       out.push(this.compileJs('import Router from \'demo-app/router\';\nRouter.reopen({\n  updateUrlBar: Ember.on(\'didTransition\', function() {\n    window.parent.demoAppUrl = this.get(\'url\');\n    window.parent.updateDemoAppUrl();\n  })\n});\nexport default {name: \'router\',\n initialize: function() {}\n};\n', 'demo-app/initializers/router'));
+
+      // Add config
       out.push(this.compileJs('export default {modulePrefix:"demo-app"}', 'demo-app/config/environment'));
 
       // Add boot code

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -48,7 +48,6 @@ export default Em.Service.extend({
       // Add router
       if (!gist.get('files').findBy('nameWithModule', 'demo-app/router')) {
         out.push(this.compileJs(blueprints.router, 'demo-app/router'));
-        console.error('Missing a router.js See issue https://github.com/ember-cli/ember-twiddle/issues/55#issuecomment-121724317');
       }
       out.push(this.compileJs('import Router from \'demo-app/router\';\nRouter.reopen({\n  updateUrlBar: Ember.on(\'didTransition\', function() {\n    window.parent.demoAppUrl = this.get(\'url\');\n    window.parent.updateDemoAppUrl();\n  })\n});\nexport default {name: \'router\',\n initialize: function() {}\n};\n', 'demo-app/initializers/router'));
 

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -49,10 +49,12 @@ test('deleting a gist loaded in two columns', function(assert) {
     click(anyFile);
     click(fileMenu);
     click(deleteAction);
+
     click(firstFilePicker);
     click(anyFile);
     click(fileMenu);
     click(deleteAction);
+
     andThen(function() {
       assert.equal(find('a:contains(No files available)').length, 4, 'Shows message when all files are removed.');
     });


### PR DESCRIPTION
This allows existing Ember Twiddle gists without a router.js to continue to work by making router.js optional. Users can now add a router through a blueprint. This also lets them conveniently reset the router by deleting and adding a new one.

Fixes issue #55 