### PR TITLE
Adds CodeMirror font-family fallback to monospace

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -45,7 +45,7 @@ body {
 .code .CodeMirror, .code .header ul {opacity:.3; transition: opacity .3s;}
 .code.active .CodeMirror, .code.active .header ul  {opacity:1}
 .code .CodeMirror {
-	font-family: Monaco;
+	font-family: Monaco, monospace;
 	font-size:13px;
 	line-height: 1.6;
 	height:100%;


### PR DESCRIPTION
Monaco only ships with [OS X](https://en.wikipedia.org/wiki/Monaco_(typeface)) and is currently used as the CodeMirror editor font-family.
This commit adds a fallback to the default browser monospace font if Monaco isn't available.

![fiddle-monospace](https://cloud.githubusercontent.com/assets/1205444/8873473/4f59427c-3207-11e5-8458-ab654363c3e8.png)

