### PR TITLE
Use external ember-template-compiler

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -210,8 +210,11 @@ export default Em.Service.extend({
    * @return {String}            AMD module code
    */
   compileHbs (code, filePath) {
-    let templateCode = Em.HTMLBars.precompile(code || '');
-    return this.compileJs('export default Ember.HTMLBars.template(' + templateCode + ');', filePath);
+    // TODO: Is there a way to precompile using the template compiler brought in via twiddle.json?
+    // let templateCode = Em.HTMLBars.precompile(code || '');
+
+    // Compiles all templates at runtime.
+    return this.compileJs('export default Ember.HTMLBars.compile(`' + (code || '') + '`);', filePath);
   },
 
   compileCss(code, moduleName) {

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -77,6 +77,12 @@ const availableBlueprints = {
   }
 };
 
+const requiredDependencies = [
+  'jquery',
+  'ember',
+  'ember-template-compiler'
+];
+
 /**
  * A tiny browser version of the CLI build chain.
  * or more realistically: a hacked reconstruction of it.
@@ -186,7 +192,17 @@ export default Em.Service.extend({
   },
 
   getTwiddleJson (gist) {
-    return JSON.parse(gist.get('files').findBy('filePath', 'twiddle.json').get('content'));
+    var twiddleJson = JSON.parse(gist.get('files').findBy('filePath', 'twiddle.json').get('content'));
+
+    // Fill in any missing required dependencies
+    var dependencies = JSON.parse(blueprints['twiddle.json']).dependencies;
+    Object.keys(requiredDependencies).forEach(function(dep) {
+      if (!twiddleJson.dependencies[dep] && dependencies[dep]) {
+        twiddleJson.dependencies[dep] = dependencies[dep];
+      }
+    });
+
+    return twiddleJson;
   },
 
   /**

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -196,7 +196,7 @@ export default Em.Service.extend({
 
     // Fill in any missing required dependencies
     var dependencies = JSON.parse(blueprints['twiddle.json']).dependencies;
-    Object.keys(requiredDependencies).forEach(function(dep) {
+    requiredDependencies.forEach(function(dep) {
       if (!twiddleJson.dependencies[dep] && dependencies[dep]) {
         twiddleJson.dependencies[dep] = dependencies[dep];
       }

--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
     "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.5/ember.js",
-    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.5/ember-data.js"
+    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.5/ember-data.js",
+    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.5/ember-template-compiler.js"
   }
 }


### PR DESCRIPTION
 Use external ember-template-compiler to allow for older versions of Ember.js

Fixes Issue #81 