### PR TITLE
Add support for vim, emacs, and sublime key maps

### DIFF
--- a/app/components/editor-mode-menu.js
+++ b/app/components/editor-mode-menu.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'li',
+  classNames: ['dropdown'],
+
+  actions: {
+    setKeyMap(keyMap) {
+      this.attrs.setKeyMap(keyMap);
+    }
+  }
+});

--- a/app/components/file-editor-column.js
+++ b/app/components/file-editor-column.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   focusEditor: 'focusEditor',
   selectFile: 'selectFile',
+  keyMap: 'basic',
 
   editorMode: Ember.computed('file.extension', function () {
     switch(this.get('file.extension')) {

--- a/app/components/file-menu.js
+++ b/app/components/file-menu.js
@@ -1,8 +1,7 @@
 import Ember from "ember";
 
 export default Ember.Component.extend({
-  tagName: 'ul',
-  classNames: ['nav', 'nav-pills', 'file-menu'],
+  tagName: 'li',
 
   actions: {
     addFile(type) {

--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
 import config from '../config/environment';
+import Settings from '../models/settings';
 
 const {
   computed: { equal },
@@ -28,6 +29,8 @@ export default Ember.Controller.extend({
   col2File: null,
   col1Active: equal('activeEditorCol','1'),
   col2Active: equal('activeEditorCol','2'),
+
+  settings: Settings.create(),
 
   /**
    * Errors during build
@@ -169,6 +172,12 @@ export default Ember.Controller.extend({
 
         this.send('contentsChanged');
       }
+    },
+
+    setEditorKeyMap (keyMap) {
+      const settings = this.get('settings');
+      settings.set('keyMap', keyMap);
+      settings.save();
     }
   },
 

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -1,16 +1,19 @@
 <div class="row toolbar">
-  {{file-menu model=model
-              session=session
-              activeEditorCol=activeEditorCol
-              activeFile=activeFile
-              addFile=(action "addFile")
-              renameFile=(action "renameFile")
-              removeFile=(action "removeFile")
-              saveGist="saveGist"
-              fork="fork"
-              deleteGist=(action "deleteGist")
-              signInViaGithub="signInViaGithub"
-  }}
+  <ul class="nav nav-pills file-menu">
+    {{file-menu model=model
+                session=session
+                activeEditorCol=activeEditorCol
+                activeFile=activeFile
+                addFile=(action "addFile")
+                renameFile=(action "renameFile")
+                removeFile=(action "removeFile")
+                saveGist="saveGist"
+                fork="fork"
+                deleteGist=(action "deleteGist")
+                signInViaGithub="signInViaGithub"}}
+
+    {{editor-mode-menu setKeyMap=(action "setEditorKeyMap")}}
+  </ul>
 
   <div class="title">
     {{!-- {{#if isEditingDescription}} --}}
@@ -31,11 +34,11 @@
 <div class="row twiddle-panes">
 
   <div class="col-md-4 code {{if col1Active 'active' ''}}">
-    {{file-editor-column col="1" file=col1File allFiles=model.files contentsChanged="contentsChanged"}}
+    {{file-editor-column col="1" file=col1File allFiles=model.files keyMap=settings.keyMap contentsChanged="contentsChanged"}}
   </div>
 
   <div class="col-md-4 code {{if col2Active 'active' ''}}">
-    {{file-editor-column col="2" file=col2File allFiles=model.files contentsChanged="contentsChanged"}}
+    {{file-editor-column col="2" file=col2File allFiles=model.files keyMap=settings.keyMap contentsChanged="contentsChanged"}}
   </div>
 
   <div class="col-md-4 output">

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import _merge from 'lodash/object/merge';
+
+const {
+  ObjectProxy,
+  get,
+  set
+} = Ember;
+
+export default ObjectProxy.extend({
+  storageKey: 'ember_twiddle_settings',
+
+  defaultSettings: {
+    keyMap: 'basic'
+  },
+
+  init() {
+    const storageKey = get(this, 'storageKey');
+    const defaultSettings = get(this, 'defaultSettings');
+    const localSettings = JSON.parse(localStorage.getItem(storageKey)) || {};
+
+    set(this, 'content', _merge(defaultSettings, localSettings));
+
+    this._super(...arguments);
+  },
+
+  save() {
+    const storageKey = get(this, 'storageKey');
+    const newSettings = JSON.stringify(get(this, 'content'));
+
+    localStorage.setItem(storageKey, newSettings);
+  }
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -7,6 +7,7 @@ const { computed } = Ember;
 export default DS.Model.extend({
   login: attr('string'),
   avatarUrl: attr('string'),
+
   avatarUrl32: computed('avatarUrl', function() {
     return this.get('avatarUrl') + '&s=32';
   })

--- a/app/templates/components/editor-mode-menu.hbs
+++ b/app/templates/components/editor-mode-menu.hbs
@@ -1,0 +1,10 @@
+<a class="dropdown-toggle" data-toggle="dropdown" href="#">
+  Mode <b class="caret"></b>
+</a>
+
+<ul class="dropdown-menu dropdown-menu-right">
+  <li><a {{action 'setKeyMap' 'basic'}} class="key-map-option basic">Basic</a></li>
+  <li><a {{action 'setKeyMap' 'vim'}} class="key-map-option vim">Vim</a></li>
+  <li><a {{action 'setKeyMap' 'emacs'}} class="key-map-option emacs">Emacs</a></li>
+  <li><a {{action 'setKeyMap' 'sublime'}} class="key-map-option sublime">Sublime</a></li>
+</ul>

--- a/app/templates/components/file-editor-column.hbs
+++ b/app/templates/components/file-editor-column.hbs
@@ -1,5 +1,4 @@
 <div class="header">
-
   <ul class="nav nav-pills file-picker">
     <li class="dropdown">
       {{#if allFiles.length}}
@@ -16,7 +15,7 @@
       {{/if}}
       <ul class="dropdown-menu">
       {{#each allFiles as |file|}}
-	      <li><a {{action 'selectFile' file}}>{{file.filePath}}</a></li>
+        <li><a {{action 'selectFile' file}}>{{file.filePath}}</a></li>
       {{else}}
         <li class="disabled"><a>No files available</a></li>
       {{/each}}
@@ -24,14 +23,16 @@
     </li>
   </ul>
 </div>
+
 {{#if file}}
 {{ivy-codemirror
     value         = file.content
     mode          = editorMode
+    keyMap        = keyMap
     lineNumbers   = true
     fixedGutter   = true
-    lineWrapping	= true
-    tabSize				= 2
+    lineWrapping  = true
+    tabSize       = 2
     valueUpdated  = "valueUpdated"
 }}
 {{/if}}

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -1,38 +1,37 @@
-<li class="dropdown">
-  <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-    File <b class="caret"></b>
-  </a>
-  <ul class="dropdown-menu">
-    <li>{{#link-to 'gist.new'}}New Twiddle{{/link-to}}</li>
+<a class="dropdown-toggle" data-toggle="dropdown" href="#">
+  File <b class="caret"></b>
+</a>
+
+<ul class="dropdown dropdown-menu">
+  <li>{{#link-to 'gist.new'}}New Twiddle{{/link-to}}</li>
+  <li role="presentation" class="divider"></li>
+  <li class="dropdown-submenu">
+    <a tabindex="-1" href="#">Add...</a>
+    <ul class="dropdown-menu">
+      <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
+      <li><a {{action 'addFile' 'component-hbs'}}>Component (hbs)</a></li>
+      <li><a {{action 'addFile' 'component-js'}}>Component (js)</a></li>
+      <li><a {{action 'addFile' 'model'}}>Model</a></li>
+      <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
+      <li><a {{action 'addFile' 'route'}}>Route</a></li>
+      <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
+      <li><a {{action 'addFile' 'router'}}>Router</a></li>
+      <li><a {{action 'addFile' 'css'}}>CSS</a></li>
+    </ul>
+  </li>
+  {{#if activeEditorCol}}
+    <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
+    <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
+  {{/if}}
+  {{#if session.isAuthenticated}}
     <li role="presentation" class="divider"></li>
-    <li class="dropdown-submenu">
-      <a tabindex="-1" href="#">Add...</a>
-      <ul class="dropdown-menu">
-        <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
-        <li><a {{action 'addFile' 'component-hbs'}}>Component (hbs)</a></li>
-        <li><a {{action 'addFile' 'component-js'}}>Component (js)</a></li>
-        <li><a {{action 'addFile' 'model'}}>Model</a></li>
-        <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
-        <li><a {{action 'addFile' 'route'}}>Route</a></li>
-        <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
-        <li><a {{action 'addFile' 'router'}}>Router</a></li>
-        <li><a {{action 'addFile' 'css'}}>CSS</a></li>
-      </ul>
-    </li>
-    {{#if activeEditorCol}}
-      <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
-      <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
-    {{/if}}
-    {{#if session.isAuthenticated}}
-      <li role="presentation" class="divider"></li>
-      <li><a {{action 'saveGist' model}} class="test-save-action">Save to Github Gist</a></li>
-      {{#unless model.isNew}}
-        <li><a {{action 'share'}}>Share Twiddle</a></li>
-        <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
-        <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
-      {{/unless}}
-    {{else}}
-      <li><a {{action 'signInViaGithub'}} class="test-sign-in-action">Sign in with Github to Save</a></li>
-    {{/if}}
-  </ul>
-</li>
+    <li><a {{action 'saveGist' model}} class="test-save-action">Save to Github Gist</a></li>
+    {{#unless model.isNew}}
+      <li><a {{action 'share'}}>Share Twiddle</a></li>
+      <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
+      <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
+    {{/unless}}
+  {{else}}
+    <li><a {{action 'signInViaGithub'}} class="test-sign-in-action">Sign in with Github to Save</a></li>
+  {{/if}}
+</ul>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,6 +22,7 @@ module.exports = function() {
     },
     codemirror: {
       modes: ['xml', 'javascript', 'handlebars', 'htmlmixed', 'css'],
+      keyMaps: ['emacs', 'sublime', 'vim']
     },
     'ember-cli-bootstrap-sassy': {
       'js': ['dropdown']

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-git-version": "0.0.1",
+    "ember-lodash": "0.0.5",
     "ember-notify": "3.4.0",
     "ivy-codemirror": "~1.2.0",
     "torii": "^0.5.1"

--- a/tests/integration/components/editor-mode-menu-test.js
+++ b/tests/integration/components/editor-mode-menu-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('editor-mode-menu', 'Integration | Component | editor mode menu', {
+  integration: true
+});
+
+test('it calls setKeyMap with the chosen keyMap', function(assert) {
+  assert.expect(2);
+
+  this.actions = {
+    setKeyMap(keyMap) {
+      assert.ok(true, 'setKeyMap was called');
+      assert.equal(keyMap, 'vim', 'chosen keyMap was passed to setKeyMap');
+    }
+  };
+
+  this.render(hbs`{{editor-mode-menu setKeyMap=(action "setKeyMap")}}`);
+
+  this.$('.key-map-option.vim').click();
+});

--- a/tests/unit/models/settings-test.js
+++ b/tests/unit/models/settings-test.js
@@ -1,0 +1,54 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const {
+  getProperties,
+  get,
+  set
+} = Ember;
+
+moduleFor('model:settings', 'Unit | Model | Settings', {
+  beforeEach() {
+    window.localStorage.clear();
+  },
+
+  afterEach() {
+    window.localStorage.clear();
+  }
+});
+
+test('it has default settings when no local settings are present', function(assert) {
+  assert.expect(1);
+
+  const settings = this.subject();
+
+  assert.deepEqual(getProperties(settings, 'keyMap'), {
+    keyMap: 'basic'
+  }, 'default settings are present');
+});
+
+test('settings stored in localStorage override default settings', function(assert) {
+  assert.expect(1);
+
+  const localSettings = JSON.stringify({ keyMap: 'vim' });
+  window.localStorage.setItem('ember_twiddle_settings', localSettings);
+
+  const settings = this.subject();
+
+  assert.deepEqual(getProperties(settings, 'keyMap'), {
+    keyMap: 'vim'
+  }, 'local settings overrode default settings');
+});
+
+test('save() persists settings to localStorage', function(assert) {
+  assert.expect(1);
+
+  const settings = this.subject();
+
+  set(settings, 'keyMap', 'emacs');
+  settings.save();
+
+  const anotherSettings = this.subject();
+  assert.equal(get(anotherSettings, 'keyMap'), 'emacs',
+    'new Settings has previously persisted settings');
+});


### PR DESCRIPTION
fixes https://github.com/ember-cli/ember-twiddle/issues/48

![vim-mode](https://cloud.githubusercontent.com/assets/602204/9019770/8878b8e0-37bf-11e5-9541-b50b10a63cc0.gif)

~~Right now ember-twiddle is dependent on a fork of ivy-codemirror until https://github.com/IvyApp/ivy-codemirror/pull/5 is merged in.~~

~~This is additionally dependent on https://github.com/IvyApp/ivy-codemirror/pull/7 being merged, which adds support for importing the additional key maps. It is currently working while using my fork that includes the changes in both of those PRs but could also be made to work by manually importing those key map files via bower.~~

It would probably also be cool to persist these settings somewhere but I'm not sure where you would want that done. Maybe in localStorage or a specially named gist?