### PR TITLE
Added hand cursor style for all the menu options

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -142,6 +142,9 @@ body {
 
 
 
+.dropdown-menu li:hover {
+		cursor: pointer;
+}
 
 .dropdown-submenu {
     position: relative;


### PR DESCRIPTION
Currently, in the application most of the menu options shows text cursor on hover which does not give us a feeling that it's clickable. 

In this pull request, I have added the hand cursor style for all the drop-down menu options so that it's consistent across the application. 

