### PR TITLE
Remove GitHub fork ribbon

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,11 +12,6 @@
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/ember-twiddle.css">
     <link href='//fonts.googleapis.com/css?family=Maven+Pro:400,500,700' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
-    <!--[if lt IE 9]>
-      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
-    <![endif]-->
-
 
     {{content-for 'head-footer'}}
   </head>
@@ -44,11 +39,5 @@
       ga('send', 'pageview');
 
     </script>
-
-    <div class="github-fork-ribbon-wrapper right-bottom">
-        <div class="github-fork-ribbon" style="background-color:#303030;">
-            <a href="https://github.com/ember-cli/ember-twiddle" target="_blank">Fork me on GitHub</a>
-        </div>
-    </div>
   </body>
 </html>


### PR DESCRIPTION
After @miguelcobain's great work updating styles I think we could get rid of the "Fork me on GitHub" ribbon. IMHO it's way too big and distracting. We're already linking to the repo and issue tracker from the top menu. Thoughts?