### PR TITLE
Bump ember-cli to v1.13.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: node_js
 node_js:
-- '0.12'
+  - '0.12'
 notifications:
   email: false
 sudo: false
 cache:
   directories:
-  - node_modules
+    - node_modules
 before_install:
-- npm config set spin false
-- npm install -g npm@^2
+  - npm config set spin false
+  - npm install -g npm@^2
 install:
-- mkdir travis-phantomjs
-- wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-- tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-- export PATH=$PWD/travis-phantomjs:$PATH
-- npm install -g bower
-- npm install
-- bower install
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+    -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+  - npm install -g bower
+  - npm install
+  - bower install
 script:
-- npm test
-- scripts/travis-deploy.sh
+  - npm test
+  - scripts/travis-deploy.sh
 env:
   global:
-  - secure: Dwthqo6GaXQt7erj89xMa/2GRua9PTzcSKXYmxjE0O46DMuBR80JjPges0hGCWwPcdMFqsaMshSaTVF5eHc49vhaziB2sqWwLZndkRFIAsNGnBZkBpeZc9MsTNMbPP5KyJh/pG03nJLXUSz6xzMoxDNU/QHWyBYBxTlfxVGewLE=
-  - secure: H3EtrTdcXIDOjp59Mu/7KA7N2UrVgKjt2YVtW6dqby/Oa5q/jpfnomE70fhIpFTle6MavhAIujQ5awMRC/80EJXlZp5hnSd9DKyCpk70I1KoT6vm34RjZfSP9kAyRyokLwfjEkovCFltY3/i8y+8QFEVr8RkNt1VP2hY1ScFzys=
+    - secure: Dwthqo6GaXQt7erj89xMa/2GRua9PTzcSKXYmxjE0O46DMuBR80JjPges0hGCWwPcdMFqsaMshSaTVF5eHc49vhaziB2sqWwLZndkRFIAsNGnBZkBpeZc9MsTNMbPP5KyJh/pG03nJLXUSz6xzMoxDNU/QHWyBYBxTlfxVGewLE=
+    - secure: H3EtrTdcXIDOjp59Mu/7KA7N2UrVgKjt2YVtW6dqby/Oa5q/jpfnomE70fhIpFTle6MavhAIujQ5awMRC/80EJXlZp5hnSd9DKyCpk70I1KoT6vm34RjZfSP9kAyRyokLwfjEkovCFltY3/i8y+8QFEVr8RkNt1VP2hY1ScFzys=

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,3 @@
-<h2 id="title">Welcome to Ember.js</h2>
+<h2 id="title">Welcome to Ember</h2>
 
 {{outlet}}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-api-actions": "0.0.7",
     "ember-autoresize": "0.5.1",
     "ember-browserify": "^1.0.1",
-    "ember-cli": "1.13.6",
+    "ember-cli": "1.13.7",
     "ember-cli-app-version": "0.4.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-bootstrap-sassy": "0.0.18",

--- a/public/crossdomain.xml
+++ b/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>


### PR DESCRIPTION
Updates ember-cli to 1.13.7

I left out the ember-content-security-policy npm package that was added because I saw https://github.com/ember-cli/ember-twiddle/pull/109