### PR TITLE
Update default blueprint for new twiddles to use Ember 2.0

### DIFF
--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -2,8 +2,8 @@
   "version": "0.4.7",
   "dependencies": {
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
-    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.6/ember.js",
-    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.7/ember-data.js",
-    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.6/ember-template-compiler.js"
+    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.0.0/ember.js",
+    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/2.0.0-beta.1/ember-data.js",
+    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.0.0/ember-template-compiler.js"
   }
 }


### PR DESCRIPTION
Fixes issue #150

Note that Ember Twiddle itself is still using Ember 1.13.x