### PR TITLE
stops the corners of user avatar from being cut off

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -51,7 +51,6 @@ body {
 
     .user-avatar {
       display: inline-block;
-      border-radius: 50%;
       width: $topbar-control-height;
       height: $topbar-control-height;
       overflow: hidden;


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/3296888/9322615/56a0dc2e-453b-11e5-9726-7a9a84b9795f.png)



After:
![image](https://cloud.githubusercontent.com/assets/3296888/9322580/d21a69fc-453a-11e5-9c97-bc40dbbca8e2.png)

This probably looks really different with different avatars. My ears always get cut off at the tips.
