### PR TITLE
set first column active on load

### DIFF
--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -24,6 +24,7 @@ export default Ember.Controller.extend({
     this._super(...arguments);
     this.createColumns();
     this.setupWindowUpdate();
+    this.set('activeEditorCol', '1');
   },
 
   /**

--- a/tests/acceptance/columns-test.js
+++ b/tests/acceptance/columns-test.js
@@ -26,6 +26,7 @@ test('you can add and remove columns', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/', 'We are on the correct initial route');
     assert.equal(find(columns).length, 2, 'There are two columns to start');
+    assert.ok(find(firstColumn).hasClass('active'), 'The first column starts out active');
 
     find(plusGlyph).click();
   });


### PR DESCRIPTION
Small change, but currently when page loads and code panes are greyed out, can give impression that twiddle is disabled.  This seeks to highlights that is editable and people can jump right in.
