### PR TITLE
Fix twiddle title being cut off by updating ember-autoresize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "codemirror": "~5.6.0",
     "ember-cli-codemirror-shim": "~0.0.1",
     "bootstrap-sass": "~3.3.5",
-    "dom-ruler": "0.1.8",
+    "dom-ruler": "0.1.12",
     "pretender": "~0.9.0",
     "ember-inflector": "~1.3.1",
     "lodash": "~3.10.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dc-tabs": "0.1.0",
     "dedent": "^0.4.0",
     "ember-api-actions": "0.0.7",
-    "ember-autoresize": "0.5.3",
+    "ember-autoresize": "0.5.9",
     "ember-browserify": "1.0.3",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",


### PR DESCRIPTION
This should solve the multitude of issues / PRs that have tried to fix this.

tldr; the changes made to autoresize detect when a font family has loaded and reschedules the measurement code.