### PR TITLE
Update default Ember to 1.13.10 and default Ember Data to 1.13.13

### DIFF
--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -2,8 +2,8 @@
   "version": "0.4.11",
   "dependencies": {
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
-    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.9/ember.debug.js",
-    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.11/ember-data.js",
-    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.9/ember-template-compiler.js"
+    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.debug.js",
+    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js",
+    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js"
   }
 }

--- a/tests/acceptance/dependency-test.js
+++ b/tests/acceptance/dependency-test.js
@@ -30,9 +30,9 @@ test('Able to run a gist using an external dependency', function(assert) {
         '  "version": "0.4.0",\n' +
         '  "dependencies": {\n' +
         '    "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",\n' +
-        '    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.5/ember.js",\n' +
-        '    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.5/ember-template-compiler.js",\n' +
-        '    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.7/ember-data.js",\n' +
+        '    "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.js",\n' +
+        '    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js",\n' +
+        '    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js",\n' +
         '    "lodash": "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.js"\n' +
         '  }\n' +
         '}'

--- a/tests/acceptance/no-compiler-test.js
+++ b/tests/acceptance/no-compiler-test.js
@@ -21,7 +21,7 @@ test('Able to load a gist without a template compiler', function(assert) {
     },
     {
       filename: 'twiddle.json',
-      content: "{\n  \"version\": \"0.4.0\",\n  \"dependencies\": {\n    \"jquery\": \"https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js\",\n    \"ember\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.6/ember.js\"\n  }\n}"
+      content: "{\n  \"version\": \"0.4.0\",\n  \"dependencies\": {\n    \"jquery\": \"https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js\",\n    \"ember\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.js\"\n  }\n}"
     }
   ];
 

--- a/tests/acceptance/routing-test.js
+++ b/tests/acceptance/routing-test.js
@@ -33,7 +33,7 @@ test('Able to do routing in a gist', function(assert) {
     },
     {
       filename: "twiddle.json",
-      content: "{\n  \"version\": \"0.4.0\",\n  \"dependencies\": {\n    \"jquery\": \"https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js\",\n    \"ember\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.6/ember.js\",\n    \"ember-data\": \"https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.7/ember-data.js\",\n    \"ember-template-compiler\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.6/ember-template-compiler.js\"\n  }\n}"
+      content: "{\n  \"version\": \"0.4.0\",\n  \"dependencies\": {\n    \"jquery\": \"https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js\",\n    \"ember\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.js\",\n    \"ember-data\": \"https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js\",\n    \"ember-template-compiler\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js\"\n  }\n}"
     }
   ];
 


### PR DESCRIPTION
Also reduces deprecation warnings during tests.