### PR TITLE
Add service blueprint

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -64,6 +64,10 @@ const availableBlueprints = {
     blueprint: 'route',
     filePath: 'my-route/route.js',
   },
+  'service': {
+    blueprint: 'service',
+    filePath: 'services/my-service.js'
+  },
   'template': {
     blueprint: 'template',
     filePath: 'my-route/template.hbs',

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -20,6 +20,7 @@
       <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
       <li><a {{action 'addFile' 'route'}}>Route</a></li>
       <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
+      <li><a {{action 'addFile' 'service'}} class="add-service-link">Service</a></li>
       <li><a {{action 'addFile' 'router'}}>Router</a></li>
       <li><a {{action 'addFile' 'css'}}>CSS</a></li>
     </ul>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -85,12 +85,13 @@ function getEmberCLIBlueprints() {
   var cliPath = 'node_modules/ember-cli';
   var cliBlueprintFiles = {
     'app': 'app/files/app/app.js',
-    'router': 'app/files/app/router.js',
-    'component-js': 'component/files/__root__/__path__/__name__.js',
     'component-hbs': 'component/files/__root__/__templatepath__/__templatename__.hbs',
+    'component-js': 'component/files/__root__/__path__/__name__.js',
+    'controller': 'controller/files/__root__/__path__/__name__.js',
     'model': 'model/files/__root__/__path__/__name__.js',
     'route': 'route/files/__root__/__path__/__name__.js',
-    'controller': 'controller/files/__root__/__path__/__name__.js',
+    'router': 'app/files/app/router.js',
+    'service': 'service/files/__root__/__path__/__name__.js',
     'template': 'template/files/__root__/__path__/__name__.hbs',
   };
 

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -172,6 +172,32 @@ test('component without hyphen fails', function(assert){
   });
 });
 
+test('can add service', function(assert){
+  assert.expect(3);
+
+  let origFileCount;
+  promptValue = "services/my-service.js";
+  visit('/');
+  andThen(function(){
+    origFileCount = find(firstFilePickerFiles).length;
+  });
+
+  click(fileMenu);
+  click('.add-service-link');
+  click(firstFilePicker);
+
+  andThen(function() {
+    let numFiles = find(firstFilePickerFiles).length;
+    assert.equal(numFiles, origFileCount + 1, 'Added service file');
+
+    let fileNames = findMapText(`${firstFilePickerFiles}  a`);
+    assert.equal(fileNames[3], promptValue, 'Added the file with the right name');
+
+    let columnFiles = findMapText(displayedFiles);
+    assert.ok(columnFiles.contains(promptValue), 'Added file is displayed');
+  });
+});
+
 
 test('unsaved indicator', function(assert) {
   const indicator = ".test-unsaved-indicator";


### PR DESCRIPTION
Adds a service blueprint. Also sorts the blueprint list in `ember-cli-build.js` alphabetically (let me know if you'd prefer a separate commit).