### PR TITLE
Add possibility to copy own twiddle

### DIFF
--- a/app/components/file-menu.js
+++ b/app/components/file-menu.js
@@ -42,6 +42,9 @@ export default Ember.Component.extend({
     fork(model) {
       this.sendAction('fork', model);
     },
+    copy() {
+      this.sendAction('copy');
+    },
     deleteGist(model) {
       this.attrs.deleteGist(model);
     },

--- a/app/gist/new/controller.js
+++ b/app/gist/new/controller.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['copyCurrentTwiddle'],
+
+  copyCurrentTwiddle: false
+});

--- a/app/gist/new/route.js
+++ b/app/gist/new/route.js
@@ -4,14 +4,18 @@ import GistRoute from "ember-twiddle/routes/gist-base-route";
 export default GistRoute.extend({
   emberCli: Ember.inject.service('ember-cli'),
 
-  model () {
-    this.store.unloadAll('gistFile');
-
+  model (params) {
     var model = this.store.createRecord('gist', {description: 'New Twiddle'});
 
-    model.get('files').pushObject(this.get('emberCli').generate('controllers/application'));
-    model.get('files').pushObject(this.get('emberCli').generate('templates/application'));
-    model.get('files').pushObject(this.get('emberCli').generate('twiddle.json'));
+    if (params.copyCurrentTwiddle) {
+      this.store.peekAll('gistFile').setEach('gist', model);
+    } else {
+      this.store.unloadAll('gistFile');
+
+      model.get('files').pushObject(this.get('emberCli').generate('controllers/application'));
+      model.get('files').pushObject(this.get('emberCli').generate('templates/application'));
+      model.get('files').pushObject(this.get('emberCli').generate('twiddle.json'));
+    }
 
     return model;
   },

--- a/app/gist/route.js
+++ b/app/gist/route.js
@@ -47,6 +47,14 @@ export default Ember.Route.extend({
       }).catch(this.catchForkError.bind(this));
     },
 
+    copy () {
+      this.transitionTo('gist.new', {
+        queryParams: {
+          copyCurrentTwiddle: true
+        }
+      });
+    },
+
     signInViaGithub () {
       this.session.open('github-oauth2').catch(function(error) {
         alert('Could not sign you in: ' + error.message);

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -10,6 +10,7 @@
                 removeFile=(action "removeFile")
                 saveGist="saveGist"
                 fork="fork"
+                copy="copy"
                 deleteGist=(action "deleteGist")
                 signInViaGithub="signInViaGithub"}}
 

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -37,6 +37,8 @@
       <li><a {{action 'embed'}}>Embed Twiddle</a></li>
       {{#unless belongsToUser}}
         <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
+      {{else}}
+        <li><a {{action 'copy'}} class="test-copy-action">Copy Twiddle</a></li>
       {{/unless}}
       <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
     {{/unless}}

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import startApp from 'ember-twiddle/tests/helpers/start-app';
 import { findMapText } from 'ember-twiddle/tests/helpers/util';
 import ErrorMessages from 'ember-twiddle/helpers/error-messages';
+import { stubValidSession } from 'ember-twiddle/tests/helpers/torii';
 
 
 const firstColumn = '.code:first-of-type';
@@ -221,5 +222,39 @@ test('unsaved indicator', function(assert) {
 
   andThen(function() {
     assert.equal(find(indicator).length, 1, "Unsaved indicator reappears after editing");
+  });
+});
+
+test('own gist can be copied into a new one', function(assert) {
+  // set owner of gist as currently logged in user
+  stubValidSession(this.application, {
+    currentUser: { login: "Gaurav0" },
+    "github-oauth2": {}
+  });
+
+  runGist([
+    {
+      filename: 'index/controller.js',
+      content: `import Ember from 'ember';
+                export default Ember.Controller.extend();`,
+    },
+    {
+      filename: 'index/route.js',
+      content: 'export default Ember.Route.extend();',
+    }
+  ]);
+
+  fillIn('.title input', "my twiddle");
+  andThen(function() {
+    assert.equal(find('.title input').val(), "my twiddle");
+    assert.equal(find('.test-unsaved-indicator').length, 0, "No unsaved indicator shown");
+  });
+
+  click('.test-copy-action');
+
+  andThen(function() {
+    assert.equal(find('.title input').val(), "New Twiddle", "Description is reset");
+    assert.equal(find('.test-unsaved-indicator').length, 1, "Unsaved indicator appears when gist is copied");
+    assert.equal(find('.test-copy-action').length, 0, "Menu item to copy gist is not shown anymore");
   });
 });

--- a/tests/integration/components/file-menu-test.js
+++ b/tests/integration/components/file-menu-test.js
@@ -11,6 +11,7 @@ moduleForComponent('file-menu', 'Integration | Component | file menu', {
     this.removeFileCalled = false;
     this.saveGistCalled = false;
     this.forkCalled = false;
+    this.copyCalled = false;
     this.deleteGistCalled = false;
     this.signInViaGithubCalled = false;
 
@@ -53,6 +54,7 @@ moduleForComponent('file-menu', 'Integration | Component | file menu', {
     this.on('removeFile', (file) => { this.removeFileCalled = true; this.removedFile = file; });
     this.on('saveGist', (gist) => { this.saveGistCalled = true; this.gistToSave = gist; });
     this.on('fork', (gist) => { this.forkCalled = true; this.gistToFork = gist; });
+    this.on('copy', () => { this.copyCalled = true; });
     this.on('deleteGist', (gist) => { this.deleteGistCalled = true; this.gistToDelete = gist; });
     this.on('signInViaGithub', () => { this.signInViaGithubCalled = true; });
 
@@ -65,6 +67,7 @@ moduleForComponent('file-menu', 'Integration | Component | file menu', {
                               removeFile=(action "removeFile")
                               saveGist="saveGist"
                               fork="fork"
+                              copy="copy"
                               deleteGist=(action "deleteGist")
                               signInViaGithub="signInViaGithub"}}`);
   }
@@ -113,6 +116,16 @@ test("it calls fork on clicking 'Fork Twiddle'", function(assert) {
 
   assert.ok(this.forkCalled, 'fork was called');
   assert.equal(this.gistToFork, this.gist, 'fork was called with gist to fork');
+});
+
+test("it calls copy on clicking 'Copy Twiddle'", function(assert) {
+  assert.expect(1);
+
+  // logged in user is the same as the owner of the gist
+  this.set('session.currentUser.login', 'Gaurav0');
+  this.$('.test-copy-action').click();
+
+  assert.ok(this.copyCalled, 'copy was called');
 });
 
 test("it calls deleteGist on clicking 'Delete Twiddle'", function(assert) {


### PR DESCRIPTION
If a gist owned by the authenticated user is shown, a new menu item
"Copy Twiddle" allows to copy the current files into a new Twiddle. Note
that the newly created Twiddle is not yet saved.

By this, Twiddles (e.g. Ember setup for a specific version) can be used
as a starting point without having to re-setup the whole Twiddle again
and again.

---

This addresses #78 and https://github.com/ember-cli/ember-twiddle/pull/157#issuecomment-138380066.