### PR TITLE
Copy gist route

### DIFF
--- a/app/gist/edit/copy/route.js
+++ b/app/gist/edit/copy/route.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect: function() {
+    this.transitionTo('gist.new', {
+      queryParams: {
+        copyCurrentTwiddle: true
+      }
+    });
+  }
+});

--- a/app/gist/new/route.js
+++ b/app/gist/new/route.js
@@ -20,8 +20,12 @@ export default GistRoute.extend({
     return model;
   },
 
-  setupController() {
+  setupController(controller) {
     this._super.apply(this, arguments);
+
+    // reset copyCurrentTwiddle, so it is not shown in the URL: this QP is only
+    // needed when initializing the model for this route
+    controller.set('copyCurrentTwiddle', false);
 
     this.controllerFor('gist').set('unsaved', true);
   }

--- a/app/router.js
+++ b/app/router.js
@@ -8,7 +8,9 @@ var Router = Ember.Router.extend({
 Router.map(function() {
   this.route('gist', {path: '/'}, function() {
     this.route('new', {path: '/'});
-    this.route('edit', {path: '/:id'});
+    this.route('edit', {path: '/:id'}, function() {
+      this.route('copy');
+    });
   });
   this.route('twiddles');
 });

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -254,3 +254,27 @@ test('own gist can be copied into a new one', function(assert) {
     assert.equal(outputContents('div'), 'hello world!');
   });
 });
+
+test('accessing /:gist/copy creates a new Twiddle with a copy of the gist', function(assert) {
+  runGist([
+    {
+      filename: 'application.template.hbs',
+      content: 'hello world!',
+    }
+  ]);
+
+  fillIn('.title input', "my twiddle");
+  andThen(function() {
+    assert.equal(find('.title input').val(), "my twiddle");
+    assert.equal(find('.test-unsaved-indicator').length, 0, "No unsaved indicator shown");
+  });
+
+  visit('/35de43cb81fc35ddffb2/copy');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+    assert.equal(find('.title input').val(), "New Twiddle", "Description is reset");
+    assert.equal(find('.test-unsaved-indicator').length, 1, "Unsaved indicator appears when gist is copied");
+    assert.equal(outputContents('div'), 'hello world!');
+  });
+});

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -234,13 +234,8 @@ test('own gist can be copied into a new one', function(assert) {
 
   runGist([
     {
-      filename: 'index/controller.js',
-      content: `import Ember from 'ember';
-                export default Ember.Controller.extend();`,
-    },
-    {
-      filename: 'index/route.js',
-      content: 'export default Ember.Route.extend();',
+      filename: 'application.template.hbs',
+      content: 'hello world!',
     }
   ]);
 
@@ -256,5 +251,6 @@ test('own gist can be copied into a new one', function(assert) {
     assert.equal(find('.title input').val(), "New Twiddle", "Description is reset");
     assert.equal(find('.test-unsaved-indicator').length, 1, "Unsaved indicator appears when gist is copied");
     assert.equal(find('.test-copy-action').length, 0, "Menu item to copy gist is not shown anymore");
+    assert.equal(outputContents('div'), 'hello world!');
   });
 });


### PR DESCRIPTION
This PR creates a new route `/:gist/copy` which is a shortcut to copy a gist into a new Twiddle.

This addresses #216.