### PR TITLE
Add possibility to specify EmberENV in twiddle.json

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -180,12 +180,16 @@ export default Ember.Service.extend({
 
   buildHtml (gist, appJS, appCSS) {
     let index = blueprints['index.html'];
-    let deps = this.getTwiddleJson(gist).dependencies;
+    let twiddleJSON = this.getTwiddleJson(gist);
+    let deps = twiddleJSON.dependencies;
 
     let depCssLinkTags = '';
     let depScriptTags ='';
     let appScriptTag = `<script type="text/javascript">${appJS}</script>`;
     let appStyleTag = `<style type="text/css">${appCSS}</style>`;
+
+    let EmberENV = twiddleJSON.EmberENV || {};
+    depScriptTags += `<script type="text/javascript">EmberENV = ${JSON.stringify(EmberENV)};</script>`;
 
     Object.keys(deps).forEach(function(depKey) {
       let dep = deps[depKey];

--- a/tests/acceptance/ember-env-test.js
+++ b/tests/acceptance/ember-env-test.js
@@ -1,0 +1,47 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from 'ember-twiddle/tests/helpers/start-app';
+
+module('Acceptance | EmberENV', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('Able to specify EmberENV in twiddle.json', function(assert) {
+
+  const files = [
+    {
+      filename: "twiddle.json",
+      content: `{
+                  "dependencies": {},
+                  "EmberENV": {
+                    "value": "it works"
+                  }
+                }`
+    },
+    {
+      filename: "application.controller.js",
+      content: `import Ember from 'ember';
+                export default Ember.Controller.extend({
+                  value: Ember.computed(function() {
+                    return EmberENV.value;
+                  })
+                });`
+    },
+    {
+      filename: "application.template.hbs",
+      content: "<div class='ember-env-value'>{{value}}</div>"
+    }
+  ];
+
+  runGist(files);
+
+  andThen(function() {
+    assert.equal(outputContents('.ember-env-value'), 'it works', 'EmberENV is used from twiddle.json');
+  });
+});


### PR DESCRIPTION
The value of the top-level `EmberENV` key of twidde.json is set as
`window.EmberENV` in the Twiddles' application index.html. By this,
Twiddle can be created which make use of features in Ember, which are
put behind a feature flag:

    // twiddle.json
    {
      "EmberENV": {
        "FEATURES": {
          "ember-htmlbars-component-generation": true
        }
      }
    }

---

This addresses #188