### PR TITLE
"Run now" reloads app

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -3,6 +3,7 @@ import Path from 'npm:path';
 import blueprints from '../lib/blueprints';
 import config from '../config/environment';
 import Ember from 'ember';
+import moment from 'moment';
 
 const twiddleAppName = 'demo-app';
 
@@ -204,6 +205,11 @@ export default Ember.Service.extend({
 
     index = index.replace('{{content-for \'head\'}}', `${depCssLinkTags}\n${appStyleTag}`);
     index = index.replace('{{content-for \'body\'}}', `${depScriptTags}\n${appScriptTag}`);
+
+    // replace the {{build-timestamp}} placeholder with the number of
+    // milliseconds since the Unix Epoch:
+    // http://momentjs.com/docs/#/displaying/unix-offset/
+    index = index.replace('{{build-timestamp}}', +moment());
 
     return index;
   },

--- a/blueprints/index.html
+++ b/blueprints/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>EmberTwiddle</title>
+    <meta name="build-at" content="{{build-timestamp}}">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -24,6 +24,7 @@
     "currentPath",
     "currentRouteName",
     "runGist",
+    "waitForLoadedIFrame",
     "outputPane",
     "outputContents"
   ],

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -248,6 +248,10 @@ test('own gist can be copied into a new one', function(assert) {
   click('.test-copy-action');
 
   andThen(function() {
+    waitForLoadedIFrame();
+  });
+
+  andThen(function() {
     assert.equal(find('.title input').val(), "New Twiddle", "Description is reset");
     assert.equal(find('.test-unsaved-indicator').length, 1, "Unsaved indicator appears when gist is copied");
     assert.equal(find('.test-copy-action').length, 0, "Menu item to copy gist is not shown anymore");
@@ -270,6 +274,10 @@ test('accessing /:gist/copy creates a new Twiddle with a copy of the gist', func
   });
 
   visit('/35de43cb81fc35ddffb2/copy');
+
+  andThen(function() {
+    waitForLoadedIFrame();
+  });
 
   andThen(function() {
     assert.equal(currentURL(), '/');

--- a/tests/acceptance/run-now-test.js
+++ b/tests/acceptance/run-now-test.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from 'ember-twiddle/tests/helpers/start-app';
+
+module('Acceptance | run now', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('Able to reload the Twiddle', function(assert) {
+
+  const files = [
+    {
+      filename: "application.template.hbs",
+      content: "{{input value='initial value' }}"
+    }
+  ];
+
+  runGist(files);
+
+  // turn off live reloading
+  andThen(function() {
+    find("#live-reload").click();
+  });
+
+  andThen(function() {
+    assert.equal(outputPane().find('input').val(), 'initial value');
+
+    outputPane().find('input').val('new value');
+
+    assert.equal(outputPane().find('input').val(), 'new value');
+  });
+
+  andThen(function() {
+    find(".run-now").click();
+    waitForLoadedIFrame();
+  });
+
+
+  andThen(function() {
+    assert.equal(outputPane().find('input').val(), 'initial value');
+  });
+});

--- a/tests/helpers/run-gist.js
+++ b/tests/helpers/run-gist.js
@@ -1,5 +1,3 @@
-import Ember from "ember";
-
 export default function(app, files) {
   const login = "Gaurav0";
   const gist_id = "35de43cb81fc35ddffb2";
@@ -31,23 +29,7 @@ export default function(app, files) {
     files: gistFiles
   });
 
-  let iframe_window;
-
   visit('/35de43cb81fc35ddffb2');
 
-  andThen(function() {
-    iframe_window = outputPane();
-
-    // Wait until iframe loads
-    return new Ember.RSVP.Promise(function (resolve) {
-      iframe_window.addEventListener('load', function () {
-        iframe_window.removeEventListener('load');
-        resolve();
-      });
-    });
-  });
-
-  return andThen(function() {
-    iframe_window.visit('/');
-  });
+  return waitForLoadedIFrame();
 }

--- a/tests/helpers/wait-for-loaded-iframe.js
+++ b/tests/helpers/wait-for-loaded-iframe.js
@@ -1,0 +1,21 @@
+import Ember from "ember";
+
+export default function() {
+  let iframe_window;
+
+  andThen(function() {
+    iframe_window = outputPane();
+
+    // Wait until iframe loads
+    return new Ember.RSVP.Promise(function (resolve) {
+      iframe_window.addEventListener('load', function () {
+        iframe_window.removeEventListener('load');
+        resolve();
+      });
+    });
+  });
+
+  return andThen(function() {
+    iframe_window.visit('/');
+  });
+}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,6 +4,7 @@ import {
   setResolver
 } from 'ember-qunit';
 import runGist from "./helpers/run-gist";
+import waitForLoadedIFrame from './helpers/wait-for-loaded-iframe';
 
 setResolver(resolver);
 
@@ -20,3 +21,4 @@ Ember.Test.registerHelper('outputContents', function(app, selector) {
 
 Ember.Test.registerAsyncHelper('runGist', runGist);
 
+Ember.Test.registerAsyncHelper('waitForLoadedIFrame', waitForLoadedIFrame);


### PR DESCRIPTION
The used `{{dummy-demo-app}}` component only reloads the application if
the passed `html` property changes. If nothing changes in the underlying
app, succeeding clicks on "run now" will do nothing, as the HTML doesn't
change.

To force enable the reload of the application, this commit adds a new
`<meta name="build-at" >` tag, which' value is set to the milliseconds
since the Unix Epoch. By this, the HTML changes everytime the app is
build and now the "run now" button always reloads the application.

---

This addresses #220