### PR TITLE
Add border-radius to profile pic of logged in user

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -72,6 +72,7 @@ body {
       float: left;
       margin-right: 10px;
       line-height: normal;
+      border-radius: 3px;
     }
   }
 


### PR DESCRIPTION
This makes it consistent with the profile pic rendered on GitHub.

Subtle change but makes the appearance more smoother IMHO.

---

Before

![_before](https://cloud.githubusercontent.com/assets/341877/10576536/34cfbade-7664-11e5-992a-6ba08aace0e0.png)

After

![_after](https://cloud.githubusercontent.com/assets/341877/10576541/389982e4-7664-11e5-9514-847f8a46bf0f.png)
