### PR TITLE
Allow modals (alert, confirm) in ember-twiddle

### DIFF
--- a/app/components/dummy-demo-app.js
+++ b/app/components/dummy-demo-app.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend(ResizeMixin, {
     let supportsSrcDoc = ('srcdoc' in ifrm);
 
     if (!Ember.testing && supportsSrcDoc) {
-      ifrm.sandbox = 'allow-scripts allow-forms';
+      ifrm.sandbox = 'allow-scripts allow-forms allow-modals';
       ifrm.srcdoc = this.get('html');
     }
 


### PR DESCRIPTION
Allow `alert` and `confirm` in twiddles

<img width="675" alt="screenshot 2015-10-21 20 02 37" src="https://cloud.githubusercontent.com/assets/1217/10647371/c80b2618-782f-11e5-8820-85b7fbb3cfa0.png">
