### PR TITLE
Dependencies refactoring

### DIFF
--- a/app/components/versions-menu.js
+++ b/app/components/versions-menu.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'li',
+  classNames: ['dropdown', 'versions-menu']
+});

--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -14,6 +14,7 @@ const MAX_COLUMNS = 3;
 
 export default Ember.Controller.extend({
   emberCli: inject.service('ember-cli'),
+  dependencyResolver: inject.service(),
   notify: inject.service('notify'),
   version: config.APP.version,
 
@@ -27,6 +28,9 @@ export default Ember.Controller.extend({
     this.setupWindowUpdate();
     this.set('activeEditorCol', '1');
   },
+
+  emberVersions: computed.oneWay('dependencyResolver.emberVersions'),
+  emberDataVersions: computed.oneWay('dependencyResolver.emberDataVersions'),
 
   /**
    * Output from the build, sets the `code` attr on the component
@@ -234,6 +238,15 @@ export default Ember.Controller.extend({
     contentsChanged() {
       this.set('unsaved', true);
       this.rebuildApp();
+    },
+
+    versionSelected: function(dependency, version) {
+      var gist = this.get('model');
+      var emberCli = this.get('emberCli');
+
+      emberCli.updateDependencyVersion(gist, dependency, version).then(() => {
+        this.rebuildApp();
+      });
     },
 
     liveReloadChanged(isLiveReload) {

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -15,6 +15,10 @@
                 signInViaGithub="signInViaGithub"}}
 
     {{editor-mode-menu setKeyMap=(action "setEditorKeyMap")}}
+
+    {{versions-menu versionSelected=(action "versionSelected")
+                    emberVersions=emberVersions
+                    emberDataVersions=emberDataVersions }}
   </ul>
 
   <div class="title">

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
 
+const EMBER_VERSIONS = ['2.1.0', '2.0.2', '1.13.10', '1.12.1'];
+const EMBER_DATA_VERSIONS = ['2.1.0', '2.0.1', '1.13.14'];
+
 const VERSION_REGEX = /^\d+.\d+.\d+$/;
 
 const CDN_MAP = {
@@ -26,6 +29,8 @@ const CHANNEL_FILENAME_MAP = {
 };
 
 const CHANNELS = ['release', 'beta', 'canary'];
+
+const { computed } = Ember;
 
 export default Ember.Service.extend({
   resolveDependencies: function(dependencies) {
@@ -70,5 +75,13 @@ export default Ember.Service.extend({
     var { library, fileName } = CDN_MAP[name];
 
     return `http://cdnjs.cloudflare.com/ajax/libs/${library}/${version}/${fileName}`;
-  }
+  },
+
+  emberVersions: computed(function() {
+    return [...CHANNELS, ...EMBER_VERSIONS];
+  }),
+
+  emberDataVersions: computed(function() {
+    return [...CHANNELS, ...EMBER_DATA_VERSIONS];
+  })
 });

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -19,6 +19,14 @@ const CDN_MAP = {
   }
 };
 
+const CHANNEL_FILENAME_MAP = {
+  'ember': 'ember.debug.js',
+  'ember-template-compiler': 'ember-template-compiler.js',
+  'ember-data': 'ember-data.js'
+};
+
+const CHANNELS = ['release', 'beta', 'canary'];
+
 export default Ember.Service.extend({
   resolveDependencies: function(dependencies) {
     Object.keys(dependencies).forEach((name) => {
@@ -45,7 +53,17 @@ export default Ember.Service.extend({
       return this.cdnURL(name, value);
     }
 
+    if (CHANNELS.indexOf(value) !== -1) {
+      return this.channelURL(name, value);
+    }
+
     return value;
+  },
+
+  channelURL: function(name, channel) {
+    var fileName = CHANNEL_FILENAME_MAP[name];
+
+    return `http://builds.emberjs.com/${channel}/${fileName}`;
   },
 
   cdnURL: function(name, version) {

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -1,0 +1,56 @@
+import Ember from 'ember';
+
+const VERSION_REGEX = /^\d+.\d+.\d+$/;
+
+const CDN_MAP = {
+  'ember': {
+    library: 'ember.js',
+    fileName: 'ember.debug.js'
+  },
+
+  'ember-template-compiler': {
+    library: 'ember.js',
+    fileName: 'ember-template-compiler.js'
+  },
+
+  'ember-data': {
+    library: 'ember-data.js',
+    fileName: 'ember-data.js'
+  }
+};
+
+export default Ember.Service.extend({
+  resolveDependencies: function(dependencies) {
+    Object.keys(dependencies).forEach((name) => {
+      var value = dependencies[name];
+
+      dependencies[name] = this.resolveDependency(name, value);
+    });
+  },
+
+  resolveDependency: function(name, value) {
+    switch (name) {
+      case 'ember':
+      case 'ember-template-compiler':
+      case 'ember-data':
+        return this.resolveEmberDependency(name, value);
+
+      default:
+        return value;
+    }
+  },
+
+  resolveEmberDependency: function(name, value) {
+    if (VERSION_REGEX.test(value)) {
+      return this.cdnURL(name, value);
+    }
+
+    return value;
+  },
+
+  cdnURL: function(name, version) {
+    var { library, fileName } = CDN_MAP[name];
+
+    return `http://cdnjs.cloudflare.com/ajax/libs/${library}/${version}/${fileName}`;
+  }
+});

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -264,6 +264,26 @@ export default Ember.Service.extend({
     return twiddleJson;
   },
 
+  updateDependencyVersion: function(gist, dependencyName, version) {
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      var twiddle = gist.get('files').findBy('filePath', 'twiddle.json');
+
+      var json;
+      try {
+        json = JSON.parse(twiddle.get('content'));
+      } catch (e) {
+        return reject(e);
+      }
+
+      json.dependencies[dependencyName] = version;
+
+      json = JSON.stringify(json, null, '  ');
+      twiddle.set('content', json);
+
+      resolve();
+    });
+  },
+
   /**
    * Compile a javascript file. This means that we
    * transform it using Babel.

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -97,6 +97,8 @@ const requiredDependencies = [
  * source code at https://github.com/ember-cli/ember-cli
  */
 export default Ember.Service.extend({
+  dependencyResolver: Ember.inject.service(),
+
   init () {
     this._super();
     this.set('store', this.container.lookup("service:store"));
@@ -255,6 +257,9 @@ export default Ember.Service.extend({
         twiddleJson.dependencies[dep] = dependencies[dep];
       }
     });
+
+    var dependencyResolver = this.get('dependencyResolver');
+    dependencyResolver.resolveDependencies(twiddleJson.dependencies);
 
     return twiddleJson;
   },

--- a/app/templates/components/versions-menu.hbs
+++ b/app/templates/components/versions-menu.hbs
@@ -1,0 +1,25 @@
+<a class="dropdown-toggle" data-toggle="dropdown" href="#">
+  Dependencies <b class="caret"></b>
+</a>
+
+<ul class="dropdown dropdown-menu">
+  <li class="dropdown-submenu">
+    <a tabindex="-1">Ember.js</a>
+
+    <ul class="dropdown dropdown-menu" >
+      {{#each emberVersions as |version| }}
+        <li><a class="test-set-ember-version" {{action versionSelected "ember" version }}>{{version}}</a></li>
+      {{/each}}
+    </ul>
+  </li>
+
+  <li class="dropdown-submenu">
+    <a tabindex="-1">Ember-Data</a>
+
+    <ul class="dropdown dropdown-menu" >
+      {{#each emberDataVersions as |version| }}
+        <li><a class="test-set-ember-data-version" {{action versionSelected "ember-data" version }}>{{version}}</a></li>
+      {{/each}}
+    </ul>
+  </li>
+</ul>

--- a/tests/acceptance/dependency-test.js
+++ b/tests/acceptance/dependency-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ember-twiddle/tests/helpers/start-app';
 
-module('Acceptance | external dependency', {
+module('Acceptance | dependencies', {
   beforeEach: function() {
     this.application = startApp();
   },
@@ -11,6 +11,40 @@ module('Acceptance | external dependency', {
     Ember.run(this.application, 'destroy');
   }
 });
+
+const TWIDDLE_SHOWING_VERSIONS = [
+  {
+    filename: "application.template.hbs",
+    content: `
+    <span class='ember-version'>{{emberVersion}}</span>
+    <span class='ember-data-version'>{{emberDataVersion}}</span>
+    `
+  },
+  {
+    filename: "application.controller.js",
+    content: `
+    import Ember from 'ember';
+    import DS from 'ember-data';
+
+    export default Ember.Controller.extend({
+    emberVersion: Ember.VERSION,
+    emberDataVersion: DS.VERSION
+    });
+    `
+  },
+  {
+    filename: 'twiddle.json',
+    content: `
+    {
+    "dependencies": {
+    "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
+    "ember": "1.13.10",
+    "ember-data": "1.13.13"
+    }
+    }
+    `
+  }
+];
 
 test('Able to run a gist using an external dependency', function(assert) {
 
@@ -45,5 +79,14 @@ test('Able to run a gist using an external dependency', function(assert) {
     const outputDiv = 'div';
 
     assert.equal(outputContents(outputDiv), '3.10.0', 'Gist including an external dependency can make use of it');
+  });
+});
+
+test('Able to resolve ember / ember-data dependencies via version only', function(assert) {
+  runGist(TWIDDLE_SHOWING_VERSIONS);
+
+  andThen(function() {
+    assert.equal(outputContents('.ember-version'), '1.13.10');
+    assert.equal(outputContents('.ember-data-version'), '1.13.13');
   });
 });

--- a/tests/acceptance/dependency-test.js
+++ b/tests/acceptance/dependency-test.js
@@ -90,3 +90,27 @@ test('Able to resolve ember / ember-data dependencies via version only', functio
     assert.equal(outputContents('.ember-data-version'), '1.13.13');
   });
 });
+
+test('Dependencies can be changed via the UI', function(assert) {
+  runGist(TWIDDLE_SHOWING_VERSIONS);
+
+  andThen(function() {
+    assert.equal(outputContents('.ember-version'), '1.13.10');
+    assert.equal(outputContents('.ember-data-version'), '1.13.13');
+  });
+
+  andThen(function() {
+    click('.versions-menu .dropdown-toggle');
+    click('.test-set-ember-version:contains("2.1.0")');
+
+    click('.versions-menu .dropdown-toggle');
+    click('.test-set-ember-data-version:contains("2.1.0")');
+
+    waitForLoadedIFrame();
+  });
+
+  andThen(function() {
+    assert.equal(outputContents('.ember-version'), '2.1.0');
+    assert.equal(outputContents('.ember-data-version'), '2.1.0');
+  });
+});

--- a/tests/integration/components/versions-menu-test.js
+++ b/tests/integration/components/versions-menu-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('versions-menu', 'Integration | Component | versions menu', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  this.on("versionSelected", function(name, version) {
+    assert.equal(name, 'ember');
+    assert.equal(version, '1.2.3');
+  });
+
+  this.set('emberVersions', ['1.2.3']);
+  this.render(hbs`{{versions-menu versionSelected=(action "versionSelected")
+                                  emberVersions=emberVersions }}`);
+
+  this.$('.test-set-ember-version:contains("1.2.3")').click();
+});

--- a/tests/unit/services/dependency-resolver-test.js
+++ b/tests/unit/services/dependency-resolver-test.js
@@ -63,3 +63,57 @@ test('it resolves version for ember-data', function(assert) {
     'ember-data': 'http://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.12.1/ember-data.js'
   });
 });
+
+test('release channel can be specified for version', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember': 'release',
+    'ember-template-compiler': 'release',
+    'ember-data': 'release',
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember': 'http://builds.emberjs.com/release/ember.debug.js',
+    'ember-template-compiler': 'http://builds.emberjs.com/release/ember-template-compiler.js',
+    'ember-data': 'http://builds.emberjs.com/release/ember-data.js'
+  });
+});
+
+test('beta channel can be specified for version', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember': 'beta',
+    'ember-template-compiler': 'beta',
+    'ember-data': 'beta',
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember': 'http://builds.emberjs.com/beta/ember.debug.js',
+    'ember-template-compiler': 'http://builds.emberjs.com/beta/ember-template-compiler.js',
+    'ember-data': 'http://builds.emberjs.com/beta/ember-data.js'
+  });
+});
+
+test('canary channel can be specified for version', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember': 'canary',
+    'ember-template-compiler': 'canary',
+    'ember-data': 'canary',
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember': 'http://builds.emberjs.com/canary/ember.debug.js',
+    'ember-template-compiler': 'http://builds.emberjs.com/canary/ember-template-compiler.js',
+    'ember-data': 'http://builds.emberjs.com/canary/ember-data.js'
+  });
+});

--- a/tests/unit/services/dependency-resolver-test.js
+++ b/tests/unit/services/dependency-resolver-test.js
@@ -1,0 +1,65 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:dependency-resolver', 'Unit | Service | dependency resolver');
+
+test('resolveDependencies() leaves URLs untouched', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    jquery: 'http://my-cdn.com/1.2.3/jquery.js',
+    ember: 'https://my-cdn.com/1.2.3/ember.js',
+    'ember-template-compiler': 'http://my-cdn.com/1.2.3/ember-template-compiler.js',
+    'ember-data': 'http://my-cdn.com/1.2.3/ember-data.js'
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    jquery: 'http://my-cdn.com/1.2.3/jquery.js',
+    ember: 'https://my-cdn.com/1.2.3/ember.js',
+    'ember-template-compiler': 'http://my-cdn.com/1.2.3/ember-template-compiler.js',
+    'ember-data': 'http://my-cdn.com/1.2.3/ember-data.js'
+  });
+});
+
+test('it resolves version for ember', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    ember: '1.12.1'
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    ember: 'http://cdnjs.cloudflare.com/ajax/libs/ember.js/1.12.1/ember.debug.js'
+  });
+});
+
+test('it resolves version for ember-template-compiler', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember-template-compiler': '1.12.1'
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember-template-compiler': 'http://cdnjs.cloudflare.com/ajax/libs/ember.js/1.12.1/ember-template-compiler.js'
+  });
+});
+
+test('it resolves version for ember-data', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember-data': '1.12.1'
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember-data': 'http://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.12.1/ember-data.js'
+  });
+});

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -68,3 +68,29 @@ test("getTwiddleJson() resolves dependencies", function(assert) {
     'jquery': "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
   });
 });
+
+test("updateDependencyVersion() updates the version of the dependency in twiddle.json", function(assert) {
+  assert.expect(1);
+
+  var service = this.subject();
+
+  var gist = Ember.Object.create({
+    files: Ember.A([Ember.Object.create({
+      filePath: 'twiddle.json',
+      content: `
+        {
+          "dependencies": {
+            "ember": "1.13.9"
+          }
+        }
+      `
+    })])
+  });
+
+  service.updateDependencyVersion(gist, 'ember', 'release').then(function() {
+    var updatedContent = gist.get('files').findBy('filePath', 'twiddle.json').get('content');
+    var parsed = JSON.parse(updatedContent);
+
+    assert.equal(parsed.dependencies.ember, 'release');
+  });
+});

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 moduleFor('service:ember-cli', 'Unit | Service | ember cli', {
   // Specify the other units that are required for this test.
-  needs: ['model:gist','model:gistFile']
+  needs: ['model:gist','model:gistFile', 'service:dependency-resolver']
 });
 
 // Replace this with your real tests.
@@ -37,5 +37,34 @@ test('compiling a gist works', function(assert) {
       assert.ok(output.indexOf('define("demo-app/controllers/application"')>-1, 'build contains controller');
       assert.ok(output.indexOf('define("demo-app/config/environment"')>-1, 'build contains config');
     });
+  });
+});
+
+test("getTwiddleJson() resolves dependencies", function(assert) {
+  var service = this.subject();
+
+  var gist = Ember.Object.create({
+    files: Ember.A([Ember.Object.create({
+      filePath: 'twiddle.json',
+      content: `
+        {
+          "dependencies": {
+            "ember": "1.13.9",
+            "ember-template-compiler": "2.0.1",
+            "ember-data": "1.12.1",
+            "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
+          }
+        }
+      `
+    })])
+  });
+
+  var twiddleJson = service.getTwiddleJson(gist);
+
+  assert.deepEqual(twiddleJson.dependencies, {
+    'ember': "http://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.9/ember.debug.js",
+    'ember-template-compiler': "http://cdnjs.cloudflare.com/ajax/libs/ember.js/2.0.1/ember-template-compiler.js",
+    'ember-data': "http://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.12.1/ember-data.js",
+    'jquery': "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
   });
 });


### PR DESCRIPTION
- allow to specify version instead of full URL for `ember`, `ember-template-compiler` and `ember-data`
- allow release channels: `release`, `beta` and `canary`
- add menu item to update version for `ember` and `ember-data` via UI

---



![versions-first-try mov](https://cloud.githubusercontent.com/assets/341877/10674423/0783b122-78fb-11e5-9e68-4f19da4a7e36.gif)

---

![screen shot 2015-10-22 at 20 25 41](https://cloud.githubusercontent.com/assets/341877/10674449/2b84adce-78fb-11e5-884d-7f475acb5bb0.png)

---

![screen shot 2015-10-22 at 20 26 09](https://cloud.githubusercontent.com/assets/341877/10674451/2e055986-78fb-11e5-85ff-4b7decc2a003.png)
