### PR TITLE
Overhaul /twiddles

### DIFF
--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -12,6 +12,10 @@ export default Ember.Component.extend({
     },
     signOut() {
       this.sendAction('signOut');
+    },
+
+    showTwiddles() {
+      this.sendAction('showTwiddles');
     }
   }
 });

--- a/app/gist/route.js
+++ b/app/gist/route.js
@@ -11,6 +11,13 @@ export default Ember.Route.extend({
     });
   },
 
+  deactivate () {
+    var gist = this.controller.get('model');
+    if (gist.get('isNew')) {
+      this.store.unloadRecord(gist);
+    }
+  },
+
   actions: {
     saveGist (gist) {
       var newGist = gist.get('isNew');
@@ -64,6 +71,10 @@ export default Ember.Route.extend({
 
     signOut () {
       this.session.close();
+    },
+
+    showTwiddles: function() {
+      this.transitionTo('twiddles');
     }
   },
 

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -32,6 +32,7 @@
               version=version
               signInViaGithub="signInViaGithub"
               signOut="signOut"
+              showTwiddles="showTwiddles"
   }}
 </div>
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -88,6 +88,11 @@ body {
     margin: 13px auto;
     text-align: center;
 
+    .saved-twiddles-header {
+      color: #faf2ee;
+      font-size: 15px;
+    }
+
     .indicator {
       text-transform: uppercase;
       font-weight: bold;

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -4,45 +4,47 @@
 
 <ul class="dropdown dropdown-menu">
   <li>{{#link-to 'gist.new'}}New Twiddle{{/link-to}}</li>
-  <li role="presentation" class="divider"></li>
-  <li class="dropdown-submenu">
-    <a tabindex="-1" href="#">Add...</a>
-    <ul class="dropdown-menu">
-      <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
-      <li class="dropdown-submenu">
-        <a {{action 'addComponent'}} class="add-component-link">Component (js and hbs)</a>
-        <ul class="'dropdown dropdown-menu">
-          <li><a {{action 'addFile' 'component-hbs'}}>hbs only</a></li>
-          <li><a {{action 'addFile' 'component-js'}}>js only</a></li>
-        </ul>
-      </li>
-      <li><a {{action 'addFile' 'model'}}>Model</a></li>
-      <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
-      <li><a {{action 'addFile' 'route'}}>Route</a></li>
-      <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
-      <li><a {{action 'addFile' 'service'}} class="test-add-service-link">Service</a></li>
-      <li><a {{action 'addFile' 'router'}}>Router</a></li>
-      <li><a {{action 'addFile' 'css'}}>CSS</a></li>
-    </ul>
-  </li>
-  {{#if activeEditorCol}}
-    <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
-    <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
-  {{/if}}
-  {{#if session.isAuthenticated}}
+  {{#if model}}
     <li role="presentation" class="divider"></li>
-    <li><a {{action 'saveGist' model}} class="test-save-action">Save to Github Gist</a></li>
-    {{#unless model.isNew}}
-      <li><a {{action 'share'}}>Share Twiddle</a></li>
-      <li><a {{action 'embed'}}>Embed Twiddle</a></li>
-      {{#unless belongsToUser}}
-        <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
-      {{else}}
-        <li><a {{action 'copy'}} class="test-copy-action">Copy Twiddle</a></li>
+    <li class="dropdown-submenu">
+      <a tabindex="-1" href="#">Add...</a>
+      <ul class="dropdown-menu">
+        <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
+        <li class="dropdown-submenu">
+          <a {{action 'addComponent'}} class="add-component-link">Component (js and hbs)</a>
+          <ul class="'dropdown dropdown-menu">
+            <li><a {{action 'addFile' 'component-hbs'}}>hbs only</a></li>
+            <li><a {{action 'addFile' 'component-js'}}>js only</a></li>
+          </ul>
+        </li>
+        <li><a {{action 'addFile' 'model'}}>Model</a></li>
+        <li><a {{action 'addFile' 'controller'}}>Controller</a></li>
+        <li><a {{action 'addFile' 'route'}}>Route</a></li>
+        <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
+        <li><a {{action 'addFile' 'service'}} class="test-add-service-link">Service</a></li>
+        <li><a {{action 'addFile' 'router'}}>Router</a></li>
+        <li><a {{action 'addFile' 'css'}}>CSS</a></li>
+      </ul>
+    </li>
+    {{#if activeEditorCol}}
+      <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
+      <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
+    {{/if}}
+    {{#if session.isAuthenticated}}
+      <li role="presentation" class="divider"></li>
+      <li><a {{action 'saveGist' model}} class="test-save-action">Save to Github Gist</a></li>
+      {{#unless model.isNew}}
+        <li><a {{action 'share'}}>Share Twiddle</a></li>
+        <li><a {{action 'embed'}}>Embed Twiddle</a></li>
+        {{#unless belongsToUser}}
+          <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
+        {{else}}
+          <li><a {{action 'copy'}} class="test-copy-action">Copy Twiddle</a></li>
+        {{/unless}}
+        <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
       {{/unless}}
-      <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
-    {{/unless}}
-  {{else}}
-    <li><a {{action 'signInViaGithub'}} class="test-sign-in-action">Sign in with Github to Save</a></li>
+    {{else}}
+      <li><a {{action 'signInViaGithub'}} class="test-sign-in-action">Sign in with Github to Save</a></li>
+    {{/if}}
   {{/if}}
 </ul>

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -3,7 +3,7 @@
 </a>
 
 <ul class="dropdown dropdown-menu">
-  <li>{{#link-to 'gist.new'}}New Twiddle{{/link-to}}</li>
+  <li>{{#link-to 'gist.new' class="test-new-twiddle" }}New Twiddle{{/link-to}}</li>
   {{#if model}}
     <li role="presentation" class="divider"></li>
     <li class="dropdown-submenu">

--- a/app/templates/components/user-menu.hbs
+++ b/app/templates/components/user-menu.hbs
@@ -11,6 +11,8 @@
         {{userName}} <b class="caret"></b>
       </a>
       <ul class="dropdown-menu dropdown-menu-right">
+        <li><a {{action 'showTwiddles'}} class="test-show-twiddles">My Saved Twiddles</a></li>
+        <li role="presentation" class="divider"></li>
         <li><a {{action 'signOut'}} class="test-sign-out">Sign out</a></li>
       </ul>
     </li>

--- a/app/twiddles/template.hbs
+++ b/app/twiddles/template.hbs
@@ -1,4 +1,17 @@
-<h1 class="test-twiddles-header">My Saved Twiddles</h1>
+<div class="row toolbar">
+  <ul class="nav nav-pills file-menu">
+    {{file-menu}}
+  </ul>
+
+  <div class="title">
+    <h1 class="saved-twiddles-header">My Saved Twiddles</h1>
+  </div>
+
+  {{user-menu session=session
+              version=version
+              signInViaGithub="signInViaGithub"
+              signOut="signOut" }}
+</div>
 
 <table class="saved-twiddles">
   <thead>

--- a/tests/acceptance/twiddles-test.js
+++ b/tests/acceptance/twiddles-test.js
@@ -41,7 +41,7 @@ test('visiting /twiddles', function(assert) {
   visit('/twiddles');
 
   andThen(function() {
-    assert.equal($('h1.test-twiddles-header').text().trim(), "My Saved Twiddles");
+    assert.equal($('.saved-twiddles-header').text().trim(), "My Saved Twiddles");
 
     assert.equal($('.saved-twiddles tr').length, 2);
     assert.equal($('.saved-twiddles tr').eq(0).find('.test-gist-id').text().trim(), '35de43cb81fc35ddffb2');

--- a/tests/acceptance/twiddles-test.js
+++ b/tests/acceptance/twiddles-test.js
@@ -54,3 +54,19 @@ test('visiting /twiddles', function(assert) {
     assert.equal(currentURL(), '/35de43cb81fc35ddffb2', 'Able to click on a twiddle and go to the twiddle');
   });
 });
+
+test('a new twiddle can be created via File menu', function(assert) {
+  visit('/twiddles');
+  click('.dropdown-menu .test-new-twiddle');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/', 'Empty twiddle page is shown');
+
+    // it can be navigated back to the list of twiddles via the user menu
+    click('.user-menu .test-show-twiddles');
+  });
+
+  andThen(function() {
+    assert.equal(currentURL(), '/twiddles');
+  });
+});

--- a/tests/integration/components/file-menu-test.js
+++ b/tests/integration/components/file-menu-test.js
@@ -145,3 +145,10 @@ test("it calls signInViaGithub when clicking on 'Sign In To Github To Save'", fu
 
   assert.ok(this.signInViaGithubCalled, 'signInViaGithub was called');
 });
+
+test("it only renders 'New Twiddle' menu item, when no model is specified", function(assert) {
+  this.render(hbs`{{file-menu}}`);
+
+  assert.equal(this.$('.dropdown-menu li').length, 1, "only one menu item is rendered");
+  assert.equal(this.$('.dropdown-menu li').text().trim(), "New Twiddle");
+});

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -7,6 +7,7 @@ moduleForComponent('user-menu', 'Integration | Component | user menu', {
   beforeEach() {
     this.signInViaGithubCalled = false;
     this.signOutCalled = false;
+    this.showTwiddlesCalled = false;
 
     this.set('session', Ember.Object.create({
       isOpening: false,
@@ -20,11 +21,13 @@ moduleForComponent('user-menu', 'Integration | Component | user menu', {
 
     this.on('signInViaGithub', () => { this.signInViaGithubCalled = true; });
     this.on('signOut', () => { this.signOutCalled = true; });
+    this.on('showTwiddles', () => { this.showTwiddlesCalled = true; });
 
     this.render(hbs`{{user-menu session=session
                                 version=version
                                 signInViaGithub="signInViaGithub"
-                                signOut="signOut"}}`);
+                                signOut="signOut"
+                                showTwiddles="showTwiddles" }}`);
   }
 });
 
@@ -43,4 +46,13 @@ test('it calls signOut upon clicking Sign Out', function(assert) {
   this.$('.test-sign-out').click();
 
   assert.ok(this.signOutCalled, 'signOut was called');
+});
+
+test('it calls showTwiddles upon clicking "My Saved Twiddles"', function(assert) {
+  assert.expect(1);
+
+  this.set('session.isAuthenticated', true);
+  this.$('.test-show-twiddles').click();
+
+  assert.ok(this.showTwiddlesCalled, 'showTwiddles was called');
 });


### PR DESCRIPTION
This makes the look of `/twiddles` consistent with the other look by rendering the toolbar. Also, the user menu now has a link which navigates to the `/twiddles` route.

---

*Before*

![screen shot 2015-10-23 at 14 36 26](https://cloud.githubusercontent.com/assets/341877/10692675/8a459934-7993-11e5-8f5f-fd47be39382c.png)

---

*After*

![screen shot 2015-10-23 at 14 36 39](https://cloud.githubusercontent.com/assets/341877/10692680/8eb255e8-7993-11e5-9c27-68c7d5cfff88.png)

---

Added *My Saved Twiddles* menu item in user menu

![screen shot 2015-10-23 at 14 37 41](https://cloud.githubusercontent.com/assets/341877/10692698/a4714f7e-7993-11e5-93b9-0d1e21aa64a3.png)

---

*In action*

![overhaul-twiddles mov](https://cloud.githubusercontent.com/assets/341877/10692842/6b062272-7994-11e5-85a5-0954581d3cd1.gif)
