### PR TITLE
Implement logout on /twiddles route

### DIFF
--- a/app/twiddles/route.js
+++ b/app/twiddles/route.js
@@ -13,5 +13,13 @@ export default Ember.Route.extend({
 
   model() {
     return this.store.findAll('gist');
+  },
+
+  actions: {
+    signOut: function() {
+      this.session.close().then(() => {
+        this.transitionTo('/');
+      });
+    }
   }
 });

--- a/tests/acceptance/twiddles-test.js
+++ b/tests/acceptance/twiddles-test.js
@@ -70,3 +70,12 @@ test('a new twiddle can be created via File menu', function(assert) {
     assert.equal(currentURL(), '/twiddles');
   });
 });
+
+test('signing out navigates to the new twiddle route', function(assert) {
+  visit('/twiddles');
+  click('.user-menu .test-sign-out');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/', 'Empty twiddle page is shown');
+  });
+});


### PR DESCRIPTION
A logout on the /twiddles route navigates to the page where a new, empty
twiddle is shown.