### PR TITLE
Use arrow function to preserve this.

### DIFF
--- a/app/gist/route.js
+++ b/app/gist/route.js
@@ -30,7 +30,7 @@ export default Ember.Route.extend({
       gist.save().then(() => {
         this.get('notify').info(`Saved to Gist ${gist.get('id')} on Github`);
         if(newGist) {
-          this.transitionTo('gist.edit', gist).then(function() {
+          this.transitionTo('gist.edit', gist).then(() => {
             this.send('setSaved');
           });
         } else {


### PR DESCRIPTION
This previously caused an error when saving because `this` wasn't being preserved.

Prior error:

![screenshot](https://monosnap.com/file/QmrPw2dESDWzGmyHE9KKbE3RX3D0Ss.png)