### PR TITLE
Add 'helper' blueprint

### DIFF
--- a/app/components/file-menu.js
+++ b/app/components/file-menu.js
@@ -14,6 +14,9 @@ export default Ember.Component.extend({
     addComponent() {
       this.attrs.addComponent();
     },
+    addHelper() {
+      this.attrs.addHelper();
+    },
     addFile(type) {
       this.attrs.addFile(type);
     },

--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -323,7 +323,7 @@ export default Ember.Controller.extend({
     },
 
     addHelper() {
-      let type = 'helper'
+      let type = 'helper';
       let fileProperties = this.get('emberCli').buildProperties(type);
       let filePath = prompt('File path', fileProperties.filePath);
       let splitFilePath = filePath.split('/');

--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -322,6 +322,24 @@ export default Ember.Controller.extend({
       });
     },
 
+    addHelper() {
+      let type = 'helper'
+      let fileProperties = this.get('emberCli').buildProperties(type);
+      let filePath = prompt('File path', fileProperties.filePath);
+      let splitFilePath = filePath.split('/');
+      let file = splitFilePath[splitFilePath.length - 1];
+      let name = file.replace('.js', '').camelize();
+
+      fileProperties = this.get('emberCli').buildProperties(type, {
+        camelizedModuleName: name
+      });
+
+      if (this.isPathInvalid(type, filePath)) {
+        return;
+      }
+      this.createFile(filePath, fileProperties);
+    },
+
     /**
      * Add a new file to the model
      * @param {String|null} type Blueprint name or null for empty file

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -5,6 +5,7 @@
                 activeEditorCol=activeEditorCol
                 activeFile=activeFile
                 addFile=(action "addFile")
+                addHelper=(action "addHelper")
                 addComponent=(action "addComponent")
                 renameFile=(action "renameFile")
                 removeFile=(action "removeFile")

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -9,10 +9,10 @@
                 addComponent=(action "addComponent")
                 renameFile=(action "renameFile")
                 removeFile=(action "removeFile")
+                deleteGist=(action "deleteGist")
                 saveGist="saveGist"
                 fork="fork"
                 copy="copy"
-                deleteGist=(action "deleteGist")
                 signInViaGithub="signInViaGithub"}}
 
     {{editor-mode-menu setKeyMap=(action "setEditorKeyMap")}}

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -61,6 +61,10 @@ const availableBlueprints = {
     blueprint: 'model',
     filePath: 'models/my-model.js',
   },
+  'helper': {
+    blueprint: 'helper',
+    filePath: 'helpers/my-helper.js'
+  },
   'route': {
     blueprint: 'route',
     filePath: 'my-route/route.js',
@@ -108,13 +112,23 @@ export default Ember.Service.extend({
     return this.store.createRecord('gistFile', this.buildProperties(type));
   },
 
-  buildProperties(type) {
+  buildProperties(type, replacements) {
     if (type in availableBlueprints) {
       let blueprint = availableBlueprints[type];
+      let content = blueprints[blueprint.blueprint];
+
+      if (replacements) {
+        Object.keys(replacements).forEach(key => {
+          let token = `<%= ${key} %>`;
+          let value = replacements[key];
+
+          content = content.replace(new RegExp(token, 'g'), value);
+        });
+      }
 
       return {
         filePath: blueprint.filePath,
-        content: blueprints[blueprint.blueprint].replace(/<\%\=(.*)\%\>/gi,'')
+        content: content.replace(/<\%\=(.*)\%\>/gi,'')
       };
     }
   },

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -22,6 +22,7 @@
         <li><a {{action 'addFile' 'route'}}>Route</a></li>
         <li><a {{action 'addFile' 'template'}} class="test-template-action">Template</a></li>
         <li><a {{action 'addFile' 'service'}} class="test-add-service-link">Service</a></li>
+        <li><a {{action 'addHelper' 'helper'}} class="test-add-helper-link">Helper</a></li>
         <li><a {{action 'addFile' 'router'}}>Router</a></li>
         <li><a {{action 'addFile' 'css'}}>CSS</a></li>
       </ul>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -93,6 +93,7 @@ function getEmberCLIBlueprints() {
     'router': 'app/files/app/router.js',
     'service': 'service/files/__root__/__path__/__name__.js',
     'template': 'template/files/__root__/__path__/__name__.hbs',
+    'helper': 'helper/files/__root__/helpers/__name__.js'
   };
 
   for (var blueprintName in cliBlueprintFiles) {

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -199,6 +199,32 @@ test('can add service', function(assert){
   });
 });
 
+test('can add helper', function(assert){
+  assert.expect(3);
+
+  let origFileCount;
+  promptValue = 'helpers/my-helper.js';
+  visit('/');
+  andThen(function(){
+    origFileCount = find(firstFilePickerFiles).length;
+  });
+
+  click(fileMenu);
+  click('.test-add-helper-link');
+  click(firstFilePicker);
+
+  andThen(function() {
+    let numFiles = find(firstFilePickerFiles).length;
+    assert.equal(numFiles, origFileCount + 1, 'Added helper file');
+
+    let fileNames = findMapText(`${firstFilePickerFiles}  a`);
+    assert.equal(fileNames[3], promptValue, 'Added the file with the right name');
+
+    let columnFiles = findMapText(displayedFiles);
+    assert.ok(columnFiles.contains(promptValue), 'Added file is displayed');
+  });
+});
+
 
 test('unsaved indicator', function(assert) {
   const indicator = ".test-unsaved-indicator";

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -123,3 +123,29 @@ test("updateDependencyVersion() updates the version of ember-template-compiler i
     assert.equal(parsed.dependencies['ember-template-compiler'], 'release');
   });
 });
+
+test("buildProperties() works as expected without replacements", function (assert) {
+  assert.expect(3);
+
+  var service = this.subject();
+  var props = service.buildProperties('helper');
+
+  assert.equal(props.filePath, 'helpers/my-helper.js', 'filePath set');
+  assert.ok(props.content, 'has content');
+  assert.ok(props.content.indexOf('<%=') === -1, 'No replacement tags in content');
+});
+
+test("buildProperties() works as expected with replacements", function (assert) {
+  assert.expect(5);
+
+  var service = this.subject();
+  var props = service.buildProperties('helper', {
+    camelizedModuleName: 'myHelper'
+  });
+
+  assert.equal(props.filePath, 'helpers/my-helper.js', 'filePath set');
+  assert.ok(props.content, 'has content');
+  assert.ok(props.content.indexOf('<%=') === -1, 'No replacement tags in content');
+  assert.ok(props.content.indexOf('myHelper(params') !== -1, 'Replacements worked');
+  assert.ok(props.content.indexOf('helper(myHelper)') !== -1, 'Replacements worked if multiple');
+});


### PR DESCRIPTION
This PR also adds a way to replace arbitrary properties in the blueprint
content when calling `buildProperties` in the emberCLI service.

Closes #191

Thanks @SaladFork for your Services PR, which I used to bounce off of.