### PR TITLE
Fix failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dc-tabs": "0.1.0",
     "dedent": "^0.4.0",
     "ember-api-actions": "0.0.7",
-    "ember-autoresize": "0.5.9",
+    "ember-autoresize": "0.5.12",
     "ember-browserify": "1.0.3",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",

--- a/tests/acceptance/twiddles-test.js
+++ b/tests/acceptance/twiddles-test.js
@@ -12,7 +12,7 @@ module('Acceptance | twiddles', {
     const file = server.create('gist-file', {
       login: "octocat",
       filename: "twiddle.json",
-      content: ''
+      content: '{ "dependencies": {} }'
     });
     server.create('gist', {
       id: '35de43cb81fc35ddffb2',


### PR DESCRIPTION
Executing the tests locally threw an error due to run-loop issues with `ember-resize`. This has been fixed upstream in https://github.com/tim-evans/ember-autoresize/pull/26.

---

Parsing an empty string for `twiddle.json` throws an error at the end of the `visting /twiddles` acceptance test, which somehow isn't failing the test but the error is logged in the console of Web Inspector.