### PR TITLE
Added wrapper around iframe to make it responsive.

### DIFF
--- a/app/components/file-menu.js
+++ b/app/components/file-menu.js
@@ -33,13 +33,15 @@ export default Ember.Component.extend({
       prompt('Ctrl + C ;-)', window.location.href);
     },
     embed() {
-      let src = window.location.href.split("?")[0];
-      src += "?fullScreen=true";
-      let iframe = document.createElement("iframe");
+      let src = window.location.href.split('?')[0];
+      src += '?fullScreen=true';
+      let responsive = document.createElement('div');
+      responsive.style.cssText = 'position:relative;height:0;overflow:hidden;max-width:100%;padding-bottom:56.25%;'; // 16:9
+      let iframe = document.createElement('iframe');
       iframe.src = src;
-      iframe.width = 800;
-      iframe.height = 600;
-      let embedCode = iframe.outerHTML;
+      iframe.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;';
+      responsive.appendChild(iframe);
+      let embedCode = responsive.outerHTML;
       prompt('Ctrl + C ;-)', embedCode);
     },
     fork(model) {


### PR DESCRIPTION
Fixes #242. The embed markup includes a wrapper div and some minimal inline styles on both it and the iframe to allow it to use the full width of the containing element. I chose 16:9 ratio. I tried 4:3 but found it to be too tall. This could be configurable, although it would mean an extra step for the user in creating the embed code.