### PR TITLE
Two-way address bar

### DIFF
--- a/app/components/dummy-demo-app.js
+++ b/app/components/dummy-demo-app.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 import ResizeMixin from 'ember-twiddle/lib/resize-mixin';
 
-const { $, on } = Ember;
+const { $, on, inject } = Ember;
 
 export default Ember.Component.extend(ResizeMixin, {
+  demoApp: inject.service(),
+
   iframeId: 'dummy-content-iframe',
   classNames: ['content'],
 
@@ -33,6 +35,8 @@ export default Ember.Component.extend(ResizeMixin, {
       ifrm.document.write('<p>Your browser doesn\'t support the <code>srcdoc</code> attribute for iframes. Ember Twiddle needs this to run safely.</p><p>Please use the latest version of Chrome, Safari or Firefox.</p><p>More information: <a href="https://github.com/ember-cli/ember-twiddle#browser-support">https://github.com/ember-cli/ember-twiddle#browser-support</a>');
       ifrm.document.close();
     }
+
+    this.get('demoApp').setCurrentIFrame(ifrm);
 
     if (Ember.testing) {
       ifrm = ifrm.contentWindow;

--- a/app/gist/route.js
+++ b/app/gist/route.js
@@ -4,6 +4,7 @@ const { inject } = Ember;
 
 export default Ember.Route.extend({
   notify: inject.service('notify'),
+  demoApp: inject.service(),
 
   titleToken: Ember.computed.readOnly('controller.model.description'),
 
@@ -77,6 +78,10 @@ export default Ember.Route.extend({
 
     showTwiddles: function() {
       this.transitionTo('twiddles');
+    },
+
+    urlChanged: function(newUrl) {
+      this.get('demoApp').postMessage({ newUrl });
     }
   },
 

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -79,7 +79,7 @@
     </div>
     {{run-or-live-reload liveReloadChanged="liveReloadChanged" runNow="runNow"}}
     <div class="url-bar">
-      <div>{{applicationUrl}}</div>
+      {{input value=applicationUrl enter="urlChanged" }}
     </div>
     {{dummy-demo-app html=buildOutput}}
     {{#if fullScreen}}

--- a/app/services/demo-app.js
+++ b/app/services/demo-app.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  setCurrentIFrame: function(iframe) {
+    this.iframe = iframe;
+  },
+
+  postMessage: function(data) {
+    if (this.iframe) {
+      this.iframe.contentWindow.postMessage(data, '*');
+    }
+  }
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -441,9 +441,10 @@ body {
   border-bottom: 1px solid #ddd;
   padding: 6px;
 }
-.url-bar > div {
+.url-bar > input {
   display: block;
   height: 25px;
+  width: 100%;
   padding: 3px;
   background: #fff;
   border: 1px solid #ddd;

--- a/blueprints/router_initializer.js
+++ b/blueprints/router_initializer.js
@@ -4,7 +4,25 @@ import config from 'demo-app/config/environment';
 
 Router.reopen({
   updateUrlBar: Ember.on('didTransition', function() {
-    window.parent.postMessage({setDemoAppUrl:this.get('url')}, config.TWIDDLE_ORIGIN);
+    window.parent.postMessage({
+      setDemoAppUrl: this.get('url')
+    }, config.TWIDDLE_ORIGIN);
+  }),
+
+  listenForOutsideDemoAppUrlChanges: Ember.on('init', function() {
+    var router = this;
+
+    function demoAppUrlChanged(event) {
+      if (event.origin !== config.TWIDDLE_ORIGIN) {
+        return;
+      }
+
+      if (event.data.newUrl) {
+        router.transitionTo(event.data.newUrl);
+      }
+    }
+
+    window.addEventListener('message', demoAppUrlChanged, false);
   })
 });
 

--- a/tests/acceptance/routing-test.js
+++ b/tests/acceptance/routing-test.js
@@ -12,51 +12,101 @@ module('Acceptance | routing', {
   }
 });
 
+const aboutLink = '.test-about-link';
+const indexLink = '.test-index-link';
+const addressBar = '.url-bar input';
+const outletText = 'p';
+
+const TWIDDLE_WITH_ROUTES = [
+  {
+    filename: "about.template.hbs",
+    content: "<p>About Page</p>"
+  },
+  {
+    filename: "index.template.hbs",
+    content: "<p>Main Page</p>"
+  },
+  {
+    filename: "application.template.hbs",
+    content: `{{#link-to "index" class="test-index-link"}}Index{{/link-to}}
+              {{#link-to "about" class="test-about-link"}}About{{/link-to}}
+
+              {{outlet}}`
+  },
+  {
+    filename: "router.js",
+    content: `import Ember from 'ember';
+              import config from './config/environment';
+
+              var Router = Ember.Router.extend({
+                location: config.locationType
+              });
+
+              Router.map(function() {
+                this.route("about");
+              });
+
+              export default Router;`
+  },
+  {
+    filename: "twiddle.json",
+    content: `{
+                "version": "0.4.0",
+                "dependencies": {
+                  "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
+                  "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.js",
+                  "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js",
+                  "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js"
+                }
+              }`
+  }
+];
+
 test('Able to do routing in a gist', function(assert) {
-
-  const files = [
-    {
-      filename: "about.template.hbs",
-      content: "<p>About Page</p>"
-    },
-    {
-      filename: "index.template.hbs",
-      content: "<p>Main Page</p>"
-    },
-    {
-      filename: "application.template.hbs",
-      content: "{{#link-to \"index\" class=\"test-index-link\"}}Index{{/link-to}}\n{{#link-to \"about\" class=\"test-about-link\"}}About{{/link-to}}\n\n{{outlet}}"
-    },
-    {
-      filename: "router.js",
-      content: "import Ember from 'ember';\nimport config from './config/environment';\n\nvar Router = Ember.Router.extend({\n  location: config.locationType\n});\n\nRouter.map(function() {\n  this.route(\"about\");\n});\n\nexport default Router;\n"
-    },
-    {
-      filename: "twiddle.json",
-      content: "{\n  \"version\": \"0.4.0\",\n  \"dependencies\": {\n    \"jquery\": \"https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js\",\n    \"ember\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.js\",\n    \"ember-data\": \"https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js\",\n    \"ember-template-compiler\": \"https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js\"\n  }\n}"
-    }
-  ];
-
-  const aboutLink = '.test-about-link';
-  const indexLink = '.test-index-link';
-  const outletText = 'p';
   let iframe_window;
 
-  runGist(files);
+  runGist(TWIDDLE_WITH_ROUTES);
 
   andThen(function() {
-    iframe_window = outputPane();
+    assert.equal(find(addressBar).val(), '/', "Correct URL is shown in address bar");
 
+    iframe_window = outputPane();
     iframe_window.click(iframe_window.find(aboutLink));
   });
 
   andThen(function() {
     assert.equal(outputContents(outletText), 'About Page', 'About Link leads to About Page being displayed');
+    assert.equal(find(addressBar).val(), '/about', "Correct URL is shown in address bar");
 
     iframe_window.click(iframe_window.find(indexLink));
   });
 
   andThen(function() {
     assert.equal(outputContents(outletText), 'Main Page', 'Index Link leads to Main Page being displayed');
+    assert.equal(find(addressBar).val(), '/', "Correct URL is shown in address bar");
+  });
+});
+
+test('URL can be changed via the address bar', function(assert) {
+  runGist(TWIDDLE_WITH_ROUTES);
+
+  andThen(function() {
+    assert.equal(find(addressBar).val(), '/', "Correct URL is shown in address bar");
+  });
+
+  fillIn(addressBar, '/about');
+  keyEvent(addressBar, 'keyup', 13);
+
+  andThen(function() {
+    assert.equal(outputContents(outletText), 'About Page', 'Changing the URL to /about and pressing enter leads to the About Page being displayed');
+    assert.equal(find(addressBar).val(), '/about', "Correct URL is shown in address bar");
+  });
+
+  fillIn(addressBar, '/');
+  keyEvent(addressBar, 'keyup', 13);
+
+  andThen(function() {
+    assert.equal(outputContents(outletText), 'Main Page', 'Changing the URL to / and pressing enter leads to the Main Page being displayed');
+    assert.equal(find(addressBar).val(), '/', "Correct URL is shown in address bar");
   });
 });


### PR DESCRIPTION
This change makes the address bar for the demo app functional, so
entering a new URL and pressing enter triggers a transition to that URL
in the demo app.

This addresses #118.

---

The basic idea is to inform the demo app via `postMessage` about a newly entered URL and do a `router.transition(newUrl)`. The current state looks as follows:

![my-name-is-url mov](https://cloud.githubusercontent.com/assets/341877/10764172/306b43b8-7ccd-11e5-8e36-8e3a752b507b.gif)


---

The tests pass locally when accessed via `localhost:4200/tests` but they **do not in PhantomJS**. I don't know enough phantom to solve this, but this might be related to security issues?