### PR TITLE
set explicit w&h on .user-avatar img

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -73,6 +73,11 @@ body {
       margin-right: 10px;
       line-height: normal;
       border-radius: 3px;
+
+      img {
+        width: $topbar-control-height;
+        height: $topbar-control-height;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #246.

If a user has not uploaded an avatar to GH they are assigned a default image. This image is returned to Twiddle as 240x240. This PR forces the image to be resized in that case.