### PR TITLE
Link to GH release page of current version

### DIFF
--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -1,10 +1,28 @@
 import Ember from 'ember';
+import config from '../config/environment';
 
 export default Ember.Component.extend({
   tagName: 'ul',
   classNames: ['nav', 'nav-pills', 'user-menu'],
 
   userName: Ember.computed.readOnly('session.currentUser.login'),
+
+  version: config.APP.version,
+  environment: config.environment,
+  currentRevision: config.currentRevision,
+
+  currentVersionLink: Ember.computed('environment', 'version', 'currentRevision', function() {
+    var baseLink = "https://github.com/ember-cli/ember-twiddle";
+    var { environment, currentRevision, version } = this.getProperties('environment', 'currentRevision', 'version');
+
+    switch (environment) {
+      case 'production':
+        return `${baseLink}/releases/tag/${version}`;
+
+      case 'staging':
+        return `${baseLink}/commit/${currentRevision}`;
+    }
+  }),
 
   actions: {
     signInViaGithub() {

--- a/app/gist/controller.js
+++ b/app/gist/controller.js
@@ -1,5 +1,4 @@
 import Ember from "ember";
-import config from '../config/environment';
 import Settings from '../models/settings';
 import ErrorMessages from 'ember-twiddle/helpers/error-messages';
 import Column from '../utils/column';
@@ -16,7 +15,6 @@ export default Ember.Controller.extend({
   emberCli: inject.service('ember-cli'),
   dependencyResolver: inject.service(),
   notify: inject.service('notify'),
-  version: config.APP.version,
 
   queryParams: ['numColumns', 'fullScreen'],
   numColumns: 2,

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -30,7 +30,6 @@
   </div>
 
   {{user-menu session=session
-              version=version
               signInViaGithub="signInViaGithub"
               signOut="signOut"
               showTwiddles="showTwiddles"

--- a/app/templates/components/user-menu.hbs
+++ b/app/templates/components/user-menu.hbs
@@ -28,7 +28,9 @@
     Help <b class="caret"></b>
   </a>
   <ul class="dropdown-menu dropdown-menu-right">
-    <li><a href="https://github.com/ember-cli/ember-twiddle" target="_blank">Ember Twiddle v{{version}}</a></li>
+    {{#if currentVersionLink}}
+      <li><a href="{{currentVersionLink}}" target="_blank" class="test-current-version-link">Ember Twiddle v{{version}}</a></li>
+    {{/if}}
     <li><a href="https://github.com/ember-cli/ember-twiddle" target="_blank">GitHub</a></li>
     <li><a href="https://github.com/ember-cli/ember-twiddle/wiki" target="_blank">Wiki</a></li>
     <li><a href="https://github.com/ember-cli/ember-twiddle/issues" target="_blank">Issue tracker</a></li>

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -17,14 +17,12 @@ moduleForComponent('user-menu', 'Integration | Component | user menu', {
         avatarUrl32: 'fake.png'
       }
     }));
-    this.set('version', '0.4.0');
 
     this.on('signInViaGithub', () => { this.signInViaGithubCalled = true; });
     this.on('signOut', () => { this.signOutCalled = true; });
     this.on('showTwiddles', () => { this.showTwiddlesCalled = true; });
 
     this.render(hbs`{{user-menu session=session
-                                version=version
                                 signInViaGithub="signInViaGithub"
                                 signOut="signOut"
                                 showTwiddles="showTwiddles" }}`);
@@ -55,4 +53,26 @@ test('it calls showTwiddles upon clicking "My Saved Twiddles"', function(assert)
   this.$('.test-show-twiddles').click();
 
   assert.ok(this.showTwiddlesCalled, 'showTwiddles was called');
+});
+
+test('shows no current version link when in development environment', function(assert) {
+  this.render(hbs`{{user-menu}}`);
+
+  assert.equal(this.$('.test-current-version-link').length, 0);
+});
+
+test('shows link to release when in production environment', function(assert) {
+  this.render(hbs`{{user-menu environment="production" version="4.0.4" }}`);
+
+  assert.equal(this.$('.test-current-version-link').length, 1);
+  assert.equal(this.$('.test-current-version-link').attr('href'), "https://github.com/ember-cli/ember-twiddle/releases/tag/4.0.4");
+  assert.equal(this.$('.test-current-version-link').text().trim(), "Ember Twiddle v4.0.4");
+});
+
+test('shows link to commit when in staging environment', function(assert) {
+  this.render(hbs`{{user-menu environment="staging" version="4.0.4-abc" currentRevision="abcdefg" }}`);
+
+  assert.equal(this.$('.test-current-version-link').length, 1);
+  assert.equal(this.$('.test-current-version-link').attr('href'), "https://github.com/ember-cli/ember-twiddle/commit/abcdefg");
+  assert.equal(this.$('.test-current-version-link').text().trim(), "Ember Twiddle v4.0.4-abc");
 });


### PR DESCRIPTION
This changes the link in the help menu to point to the release notes of the current version. Example: https://github.com/ember-cli/ember-twiddle/releases/tag/0.4.14

---

Note that the link will be broken in canary and in development, but I think that is acceptable...