### PR TITLE
Don't set version for {{user-menu}} in twiddles template

### DIFF
--- a/app/twiddles/template.hbs
+++ b/app/twiddles/template.hbs
@@ -8,7 +8,6 @@
   </div>
 
   {{user-menu session=session
-              version=version
               signInViaGithub="signInViaGithub"
               signOut="signOut" }}
 </div>


### PR DESCRIPTION
The version is read from the config inside the {{user-menu}} component,
so there is no need to pass it.

Also, this is a leftover from 55e5f895f161b1b23efc4a513b7abc66baaf5f64,
where the {{user-menu}} has been added to the toolbar but there is no
`version` property set on the controller.

---

This fixes the weird `Ember Twiddle v` menu item on `/twiddles`:

![screen shot 2015-10-28 at 16 22 03](https://cloud.githubusercontent.com/assets/341877/10793208/1a46c01c-7d90-11e5-838f-2dbacfaee5de.png)
