### PR TITLE
GitHub logo

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -74,10 +74,15 @@ body {
       line-height: normal;
       border-radius: 3px;
 
+
       img {
         width: $topbar-control-height;
         height: $topbar-control-height;
       }
+
+      &.unauthenticated {
+      	background-image: url("../images/github32-inverse-faf2ee.svg");
+    	}
     }
   }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -74,15 +74,10 @@ body {
       line-height: normal;
       border-radius: 3px;
 
-
       img {
         width: $topbar-control-height;
         height: $topbar-control-height;
       }
-
-      &.unauthenticated {
-      	background-image: url("../images/github32-inverse-faf2ee.svg");
-    	}
     }
   }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -78,6 +78,10 @@ body {
         width: $topbar-control-height;
         height: $topbar-control-height;
       }
+
+      &.unauthenticated {
+      	background: url("../images/github32-inverse-faf2ee.svg");
+      }
     }
   }
 

--- a/app/templates/components/user-menu.hbs
+++ b/app/templates/components/user-menu.hbs
@@ -18,9 +18,7 @@
     </li>
   {{else}}
     <li><a {{action 'signInViaGithub'}} class="test-sign-in sign-in">Sign in</a></li>
-    <span class="user-avatar">
-      <img class="github-logo" src="images/github32-inverse-faf2ee.svg" alt="Sign in with GitHub"/>
-    </span>
+    <span class="user-avatar unauthenticated"></span>
   {{/if}}
 {{/if}}
 <li class="dropdown">

--- a/app/templates/components/user-menu.hbs
+++ b/app/templates/components/user-menu.hbs
@@ -18,7 +18,9 @@
     </li>
   {{else}}
     <li><a {{action 'signInViaGithub'}} class="test-sign-in sign-in">Sign in</a></li>
-    <span class="user-avatar unauthenticated"></span>
+    <span class="user-avatar">
+      <img class="github-logo" src="images/github32-inverse-faf2ee.svg" alt="Sign in with GitHub"/>
+    </span>
   {{/if}}
 {{/if}}
 <li class="dropdown">

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,7 +21,8 @@ module.exports = function() {
     },
     fingerprint: {
       enabled: isProductionLikeBuild,
-      prepend: prepend
+      prepend: prepend,
+      extensions: ['js', 'css', 'png', 'svg']
     },
     codemirror: {
       modes: ['xml', 'javascript', 'handlebars', 'htmlmixed', 'css'],


### PR DESCRIPTION
Fixes #245

Removed the logo as an inline image; moved to css as background. Also, added svg extension to the fingerprint extensions. Running `ember build --environment production` results (edited for clarity):

    $ ls -LlR dist/
    dist/:

    assets/
    crossdomain.xml
    favicon.ico
    fonts/
    images/
    index.html
    loader-6f53af4abba36f6fc322973d51095b7d.css
    robots.txt

    dist/assets:

    32px-db49c8de4f267eede40a9a8843efcdec.png
    40px-1f075735090412ed7eb8077d819b19c6.png
    ember-twiddle-47f2a20e36945000322d71b7ec8c8021.css
    ember-twiddle-755932a8aed4a9d7ec7813c65f0f7369.js
    fonts/
    loader.js
    style-c83dff41a002a6c16dc202bd7eba2d11.css
    style.min-5064bed2e1319fa871d2c6f2d18789e2.css
    throbber.gif
    twiddle-deps.js
    twiddlicon.scss
    vendor-4c3fe0e37c39638084d6816477b09ae0.js
    vendor-9c86ee0e8782cff23463c264ce48dfa5.css

    dist/assets/fonts:

    twiddlicon.eot
    twiddlicon.svg
    twiddlicon.ttf
    twiddlicon.woff

    dist/fonts:

    bootstrap/

    dist/fonts/bootstrap:

    glyphicons-halflings-regular-89889688147bd7575d6327160d64e760.svg
    glyphicons-halflings-regular.eot
    glyphicons-halflings-regular.ttf
    glyphicons-halflings-regular.woff
    glyphicons-halflings-regular.woff2

    dist/images:

    github32-inverse-faf2ee-c2771c7df3c2a3da1218e809927ceffb.svg
    navigation_background-c1437f14bdf59ef96874cb26a83031fe.png

Things to note:

- loader.js not fingerprinted
- twiddle-deps.js -- is this being used?
- throbber.gif -- need to add gif ext. to fingerprint
- eot, tt, woff, and woff2 are not fingerprinted
- none of the twiddlicon files are fingerprinted, because ...
- twiddlicon.**scss** -- that shouldn't be here

I think all of that should be part of another PR as there are several things involved. Comments?