### PR TITLE
Disable Channels from Dependencies Menu

### DIFF
--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -78,10 +78,12 @@ export default Ember.Service.extend({
   },
 
   emberVersions: computed(function() {
-    return [...CHANNELS, ...EMBER_VERSIONS];
+    // CHANNELS disabled because they don't work in https
+    return [/*...CHANNELS,*/ ...EMBER_VERSIONS];
   }),
 
   emberDataVersions: computed(function() {
-    return [...CHANNELS, ...EMBER_DATA_VERSIONS];
+    // CHANNELS disabled because tehy don't work in https
+    return [/*...CHANNELS,*/ ...EMBER_DATA_VERSIONS];
   })
 });


### PR DESCRIPTION
This disables the channels options in the dependencies menu, because they don't work over https.