### PR TITLE
Fix initializer warning when testing against Ember 2.1.

### DIFF
--- a/tests/helpers/run-gist.js
+++ b/tests/helpers/run-gist.js
@@ -5,7 +5,21 @@ export default function(app, files) {
 
   files.push({
     filename: "initializers.setup-test.js",
-    content: "import Ember from 'ember';\n\nexport default {\n  name: 'setup-test',\n  initialize: function(container, app) {\n    app.setupForTesting();\n     app.injectTestHelpers();\n    window.QUnit = window.parent.QUnit;\n  }\n};"
+    content: `
+      import Ember from 'ember';
+
+      export default {
+        name: 'setup-test',
+        initialize: function() {
+          var app = arguments[1] || arguments[0];
+
+          app.setupForTesting();
+          app.injectTestHelpers();
+
+          window.QUnit = window.parent.QUnit;
+        }
+      };
+    `
   });
 
   let gistFiles = {};


### PR DESCRIPTION
Still one more to fix (container-debug-adapter).