### PR TITLE
Include icons in user menu

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -67,7 +67,7 @@ body {
     .user-avatar {
       display: inline-block;
       width: $topbar-control-height;
-      height: $topbar-control-height;
+      height: 100%;
       overflow: hidden;
       float: left;
       margin-right: 10px;
@@ -163,13 +163,16 @@ body {
   }
 
   .dropdown {
-
     &.open .dropdown-toggle {
       text-shadow: none;
       background-color: rgba(0,0,0,0.2);
       box-shadow: rgba(255,255,255,0.15) 0 1px 0px,inset rgba(0,0,0,0.17) 0 1px 1px;
       border: 1px solid transparent;
     }
+  }
+
+  .user-dropdown > .dropdown-toggle {
+    padding: 0 1em 0 0;
   }
 
   .dropdown-toggle, .sign-in {
@@ -193,7 +196,7 @@ body {
 
   .sign-in {
     cursor: pointer;
-    padding: 0 .5em;
+    padding: 0 .5em 0 0;
   }
 
   .signing-in {

--- a/app/templates/components/user-menu.hbs
+++ b/app/templates/components/user-menu.hbs
@@ -2,12 +2,12 @@
   <li class="dropdown disabled signing-in">Signing in...</li>
 {{else}}
   {{#if session.isAuthenticated}}
-    <span class="user-avatar">
-        <img src="{{session.currentUser.avatarUrl32}}" />
-    </span>
 
-    <li class="dropdown">
+    <li class="dropdown user-dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+        <span class="user-avatar">
+          <img src="{{session.currentUser.avatarUrl32}}" />
+        </span>
         {{userName}} <b class="caret"></b>
       </a>
       <ul class="dropdown-menu dropdown-menu-right">
@@ -17,8 +17,12 @@
       </ul>
     </li>
   {{else}}
-    <li><a {{action 'signInViaGithub'}} class="test-sign-in sign-in">Sign in</a></li>
-    <span class="user-avatar unauthenticated"></span>
+    <li>
+      <a {{action 'signInViaGithub'}} class="test-sign-in sign-in">
+        <span class="user-avatar unauthenticated"></span>
+        Sign in
+      </a>
+    </li>
   {{/if}}
 {{/if}}
 <li class="dropdown">


### PR DESCRIPTION
This allows clicking the icons (after login, and before) to
access the actions that they provide.

So the github icon is now clickable for signin and the user's avatar for
opening the user menu.

<img width="204" alt="screen shot 2015-11-12 at 11 31 55 am" src="https://cloud.githubusercontent.com/assets/34726/11124069/03176c50-8931-11e5-8f93-352962abb62e.png">
<img width="134" alt="screen shot 2015-11-12 at 11 31 45 am" src="https://cloud.githubusercontent.com/assets/34726/11124070/032496d2-8931-11e5-9d12-b870a16aad92.png">
