### PR TITLE
Update ember-cli-jstree to fix 'calling set on destroyed object' errors in Chrome

### DIFF
--- a/app/components/file-tree.js
+++ b/app/components/file-tree.js
@@ -6,22 +6,6 @@ const { computed } = Ember;
 export default Ember.Component.extend({
   jsTreeActionReceiver: null,
 
-  didInsertElement() {
-    if (Ember.testing) {
-      this._asyncOps = 1;
-      this._waiter = () => {
-        return this._asyncOps === 0;
-      };
-      Ember.Test.registerWaiter(this._waiter);
-    }
-  },
-
-  willDestroyElement() {
-    if (Ember.testing) {
-      Ember.Test.unregisterWaiter(this._waiter);
-    }
-  },
-
   /**
    * Calculate data for file tree
    */
@@ -86,9 +70,6 @@ export default Ember.Component.extend({
 
   actions: {
     handleSelectTreeNode(node) {
-      if (Ember.testing) {
-        this._asyncOps = 1;
-      }
       if (node.original.leaf) {
         this.attrs.openFile(node.original.path);
         return;
@@ -97,9 +78,6 @@ export default Ember.Component.extend({
     },
 
     handleReady() {
-      if (Ember.testing) {
-        this._asyncOps = 0;
-      }
     },
 
     hideFileTree() {
@@ -107,16 +85,10 @@ export default Ember.Component.extend({
     },
 
     expandAll() {
-      if (Ember.testing) {
-        this._asyncOps = 1;
-      }
       this.get('jsTreeActionReceiver').send('openAll');
     },
 
     collapseAll() {
-      if (Ember.testing) {
-        this._asyncOps = 1;
-      }
       this.get('jsTreeActionReceiver').send('closeAll');
     }
   }

--- a/app/templates/components/file-tree.hbs
+++ b/app/templates/components/file-tree.hbs
@@ -18,5 +18,4 @@
 {{ember-jstree data=fileTreeData
                actionReceiver=jsTreeActionReceiver
                eventDidSelectNode="handleSelectTreeNode"
-               eventDidBecomeReady="handleReady"
 }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-jstree": "0.1.1",
+    "ember-cli-jstree": "1.0.0",
     "ember-cli-mirage": "0.1.11",
     "ember-cli-moment-shim": "0.6.2",
     "ember-cli-qunit": "1.0.4",


### PR DESCRIPTION
Note: Some of the jstree related tests still sporadically fail in Chrome. @ritesh83 can you please look into this?