### PR TITLE
Provide moduleName for transpiled templates.

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -338,8 +338,10 @@ export default Ember.Service.extend({
     // let templateCode = Ember.HTMLBars.precompile(code || '');
 
     // Compiles all templates at runtime.
+    let moduleName = this.nameWithModule(filePath);
+
     const mungedCode = (code || '').replace(/\\/g, "\\\\"); // Prevent backslashes from being escaped
-    return this.compileJs('export default Ember.HTMLBars.compile(`' + mungedCode + '`);', filePath);
+    return this.compileJs('export default Ember.HTMLBars.compile(`' + mungedCode + '`, { moduleName: `' + moduleName + '`});', filePath);
   },
 
   compileCss(code, moduleName) {

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -149,3 +149,10 @@ test("buildProperties() works as expected with replacements", function (assert) 
   assert.ok(props.content.indexOf('myHelper(params') !== -1, 'Replacements worked');
   assert.ok(props.content.indexOf('helper(myHelper)') !== -1, 'Replacements worked if multiple');
 });
+
+test('compileHbs includes moduleName', function(assert) {
+  var service = this.subject();
+  var result = service.compileHbs('foo', 'somePath/here.hbs');
+
+  assert.ok(result.indexOf('moduleName: "demo-app/somePath/here"') > -1, 'moduleName included');
+});


### PR DESCRIPTION
This is used internally within Ember to allow local lookups in the future, it also mirrors ember-cli-htmlbars transpilation a bit better.