### PR TITLE
Escape backticks in templates.

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -340,7 +340,10 @@ export default Ember.Service.extend({
     // Compiles all templates at runtime.
     let moduleName = this.nameWithModule(filePath);
 
-    const mungedCode = (code || '').replace(/\\/g, "\\\\"); // Prevent backslashes from being escaped
+    const mungedCode = (code || '')
+            .replace(/\\/g, "\\\\") // Prevent backslashes from being escaped
+            .replace(/`/g, "\\`"); // Prevent backticks from causing syntax errors
+
     return this.compileJs('export default Ember.HTMLBars.compile(`' + mungedCode + '`, { moduleName: `' + moduleName + '`});', filePath);
   },
 

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -156,3 +156,11 @@ test('compileHbs includes moduleName', function(assert) {
 
   assert.ok(result.indexOf('moduleName: "demo-app/somePath/here"') > -1, 'moduleName included');
 });
+
+test('compileHbs can include backticks', function(assert) {
+  var template = "`stuff`";
+  var service = this.subject();
+  var result = service.compileHbs(template, 'some-path');
+
+  assert.ok(result.indexOf(template) > -1, 'original template included');
+});


### PR DESCRIPTION
Prior to this, inclusion of a backtick in a template would throw an
error.