### PR TITLE
Make it easier to do Testing

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -227,10 +227,14 @@ export default Ember.Service.extend({
     const testingEnabled = twiddleJSON.options && twiddleJSON.options["enable-testing"];
 
     if (testingEnabled) {
-      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-loader.js?${config.APP.version}"></script>`;
-      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-support.js?${config.APP.version}"></script>`;
-      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}testem.js?${config.APP.version}"></script>`;
+      const testJSFiles = ['assets/test-loader.js', 'assets/test-support.js', 'testem.js'];
+
+      testJSFiles.forEach(jsFile => {
+        depScriptTags += `<script type="text/javascript" src="${config.assetsHost}${jsFile}?${config.APP.version}"></script>`;
+      });
+
       depCssLinkTags += `<link rel="stylesheet" type="text/css" href="${config.assetsHost}assets/test-support.css?${config.APP.version}">`;
+
       testStuff += `
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -204,7 +204,7 @@ export default Ember.Service.extend({
     appJS += "window.history.pushState = function() {}; window.history.replaceState = function() {};";
 
     // Hide toolbar since it is not working
-    appCSS += `\n#qunit-testrunner-toolbar { display: none; }\n`;
+    appCSS += `\n#qunit-testrunner-toolbar, #qunit-tests a[href] { display: none; }\n`;
 
     let index = blueprints['index.html'];
     let twiddleJSON = this.getTwiddleJson(gist);

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -7,8 +7,6 @@ import moment from 'moment';
 
 const twiddleAppName = 'demo-app';
 
-const testingEnabled = true; // TODO: make this an option in UI
-
 // These files will be included if not present
 const boilerPlateJs = [
   'app',
@@ -225,6 +223,9 @@ export default Ember.Service.extend({
     });
 
     depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/twiddle-deps.js?${config.APP.version}"></script>`;
+
+    const testingEnabled = twiddleJSON.options && twiddleJSON.options["enable-testing"];
+
     if (testingEnabled) {
       depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-loader.js?${config.APP.version}"></script>`;
       depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-support.js?${config.APP.version}"></script>`;

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -200,6 +200,12 @@ export default Ember.Service.extend({
       appJS += "window.location.hash='" + gist.get('initialRoute') + "';";
     }
 
+    // avoids security error
+    appJS += "window.history.pushState = function() {}; window.history.replaceState = function() {};";
+
+    // Hide toolbar since it is not working
+    appCSS += `\n#qunit-testrunner-toolbar { display: none; }\n`;
+
     let index = blueprints['index.html'];
     let twiddleJSON = this.getTwiddleJson(gist);
     let deps = twiddleJSON.dependencies;

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -7,6 +7,8 @@ import moment from 'moment';
 
 const twiddleAppName = 'demo-app';
 
+const testingEnabled = true; // TODO: make this an option in UI
+
 // These files will be included if not present
 const boilerPlateJs = [
   'app',
@@ -208,6 +210,7 @@ export default Ember.Service.extend({
     let depScriptTags ='';
     let appScriptTag = `<script type="text/javascript">${appJS}</script>`;
     let appStyleTag = `<style type="text/css">${appCSS}</style>`;
+    let testStuff = '';
 
     let EmberENV = twiddleJSON.EmberENV || {};
     depScriptTags += `<script type="text/javascript">EmberENV = ${JSON.stringify(EmberENV)};</script>`;
@@ -222,9 +225,21 @@ export default Ember.Service.extend({
     });
 
     depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/twiddle-deps.js?${config.APP.version}"></script>`;
+    if (testingEnabled) {
+      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-loader.js?${config.APP.version}"></script>`;
+      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}assets/test-support.js?${config.APP.version}"></script>`;
+      depScriptTags += `<script type="text/javascript" src="${config.assetsHost}testem.js?${config.APP.version}"></script>`;
+      depCssLinkTags += `<link rel="stylesheet" type="text/css" href="${config.assetsHost}assets/test-support.css?${config.APP.version}">`;
+      testStuff += `
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+        <div id="ember-testing-container">
+          <div id="ember-testing"></div>
+        </div>`;
+    }
 
     index = index.replace('{{content-for \'head\'}}', `${depCssLinkTags}\n${appStyleTag}`);
-    index = index.replace('{{content-for \'body\'}}', `${depScriptTags}\n${appScriptTag}`);
+    index = index.replace('{{content-for \'body\'}}', `${depScriptTags}\n${appScriptTag}\n${testStuff}\n`);
 
     // replace the {{build-timestamp}} placeholder with the number of
     // milliseconds since the Unix Epoch:

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -103,8 +103,8 @@ const requiredDependencies = [
 export default Ember.Service.extend({
   dependencyResolver: Ember.inject.service(),
 
-  init () {
-    this._super();
+  init (...args) {
+    this._super(...args);
     this.set('store', this.container.lookup("service:store"));
   },
 

--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -1,7 +1,10 @@
 {
-  "version": "0.4.17",
+  "version": "0.5.0",
   "EmberENV": {
     "FEATURES": {}
+  },
+  "options": {
+    "enable-testing": false
   },
   "dependencies": {
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,7 +22,8 @@ module.exports = function() {
     fingerprint: {
       enabled: isProductionLikeBuild,
       prepend: prepend,
-      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'eot', 'ttf', 'woff', 'woff2', 'ico']
+      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'eot', 'ttf', 'woff', 'woff2', 'ico'],
+      exclude: ['test-loader', 'test-support', 'testem']
     },
     codemirror: {
       modes: ['xml', 'javascript', 'handlebars', 'htmlmixed', 'css'],
@@ -38,7 +39,7 @@ module.exports = function() {
     minifyCSS: { enabled: isProductionLikeBuild },
     minifyJS: { enabled: isProductionLikeBuild },
 
-    tests: process.env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
+    tests: true,
     hinting: process.env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
 
     vendorFiles: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-twiddle",
-  "version": "0.4.17",
+  "version": "0.5.0",
   "description": "Small description for ember-twiddle goes here",
   "private": true,
   "directories": {

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -191,7 +191,7 @@ test("buildHtml works when testing not enabled", function(assert) {
   assert.ok(output.indexOf("window.location.hash='/';") > 0, "output sets initialRoute");
   assert.ok(output.indexOf('EmberENV = {"FEATURES":{}}') > 0, "output contains feature flags");
   assert.ok(output.indexOf('<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"></script>') > 0, "output includes dependency");
-  assert.ok(output.indexOf('<style type="text/css">/* styles */</style>') > 0, "output includes styles");
+  assert.ok(output.indexOf('<style type="text/css">/* styles */') > 0, "output includes styles");
   assert.ok(output.indexOf('<script type="text/javascript">/* app */') > 0, "output includes the app js");
   assert.ok(output.indexOf('<div id="ember-testing-container">') === -1, "output does not contain testing container");
 });

--- a/tests/unit/services/ember-cli-test.js
+++ b/tests/unit/services/ember-cli-test.js
@@ -6,7 +6,6 @@ moduleFor('service:ember-cli', 'Unit | Service | ember cli', {
   needs: ['model:gist','model:gistFile', 'service:dependency-resolver']
 });
 
-// Replace this with your real tests.
 test('compiling a gist works', function(assert) {
   assert.expect(7);
   var service = this.subject();
@@ -163,4 +162,67 @@ test('compileHbs can include backticks', function(assert) {
   var result = service.compileHbs(template, 'some-path');
 
   assert.ok(result.indexOf(template) > -1, 'original template included');
+});
+
+test("buildHtml works when testing not enabled", function(assert) {
+  var service = this.subject();
+
+  service.getTwiddleJson = function() {
+    return {
+      "version": "0.5.0",
+      "EmberENV": {
+        "FEATURES": {}
+      },
+      "options": {
+        "enable-testing": false
+      },
+      "dependencies": {
+        "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
+      }
+    };
+  };
+
+  var gist = Ember.Object.create({
+    initialRoute: "/"
+  });
+
+  var output = service.buildHtml(gist, '/* app */', '/* styles */');
+
+  assert.ok(output.indexOf("window.location.hash='/';") > 0, "output sets initialRoute");
+  assert.ok(output.indexOf('EmberENV = {"FEATURES":{}}') > 0, "output contains feature flags");
+  assert.ok(output.indexOf('<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"></script>') > 0, "output includes dependency");
+  assert.ok(output.indexOf('<style type="text/css">/* styles */</style>') > 0, "output includes styles");
+  assert.ok(output.indexOf('<script type="text/javascript">/* app */') > 0, "output includes the app js");
+  assert.ok(output.indexOf('<div id="ember-testing-container">') === -1, "output does not contain testing container");
+});
+
+
+
+test("buildHtml works when testing is enabled", function(assert) {
+  var service = this.subject();
+
+  service.getTwiddleJson = function() {
+    return {
+      "version": "0.5.0",
+      "EmberENV": {
+        "FEATURES": {}
+      },
+      "options": {
+        "enable-testing": true
+      },
+      "dependencies": {
+        "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
+      }
+    };
+  };
+
+  var gist = Ember.Object.create({});
+
+  var output = service.buildHtml(gist, '', '');
+
+  assert.ok(output.indexOf("window.location.hash='/';") === -1, "output does not set initialRoute if not provided");
+  assert.ok(output.indexOf('<div id="qunit"></div>') > 0, "output contains qunit div");
+  assert.ok(output.indexOf('<div id="qunit-fixture"></div>') > 0, "output contains qunit fixture div");
+  assert.ok(output.indexOf('<div id="ember-testing-container">') > 0, "output contains testing container");
+  assert.ok(output.indexOf('<div id="ember-testing"></div>') > 0, "output contains testing div");
 });


### PR DESCRIPTION
This is for issue #178. We will still need some way in the UI to enable / disable testing "mode". Right now, it will be an option in twiddle.json, which also persists it.

@rwjblue @stefanpenner @joostdevries @alexspeller Please let me know what you think of my approach.

Screenshot:


![screen shot 2015-12-21 at 3 04 57 pm](https://cloud.githubusercontent.com/assets/313960/11940175/e2cd2308-a7f4-11e5-8e96-3a51b58ea6d0.png)
