### PR TITLE
Fix file deletion

### DIFF
--- a/app/models/gist-file.js
+++ b/app/models/gist-file.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import Path from 'npm:path';
 
 const { attr, belongsTo } = DS;
-const { computed, observer } = Ember;
+const { computed } = Ember;
 
 export default DS.Model.extend({
   fileType: attr('string'),

--- a/app/models/gist-file.js
+++ b/app/models/gist-file.js
@@ -34,11 +34,10 @@ export default DS.Model.extend({
   /**
     We need to register deletes.
    */
-  registerDeleteOnGist: observer('isDeleted', function() {
-    if(!this.get('gist')) {
-      return;
+  deleteRecord() {
+    this._super(...arguments);
+    if(this.get('gist')) {
+      this.get('gist').registerDeletedFile(this.get('id'));
     }
-
-    this.get('gist').registerDeletedFile(this.get('id'));
-  })
+  }
 });

--- a/tests/unit/models/gist-file-test.js
+++ b/tests/unit/models/gist-file-test.js
@@ -1,0 +1,31 @@
+import { moduleForModel, test } from 'ember-qunit';
+import Ember from 'ember';
+const { run } = Ember;
+
+moduleForModel('gist-file', 'Unit | Model | gist file', {
+  needs: ['model:gist', 'model:gist-revision']
+});
+
+test('it calls "registerDeletedFile" on gist relationship when deleting a record', function(assert) {
+  assert.expect(1);
+
+  const adapter = DS.Adapter.extend({
+    createRecord() {
+      return Ember.RSVP.resolve();
+    }
+  });
+  this.register('adapter:application', adapter);
+  const store = this.store();
+
+  run(() => {
+    const gist = store.createRecord('gist');
+    gist.registerDeletedFile = () => {
+      assert.ok(true, '"registerDeletedFile" was called');
+    };
+    const model = this.subject({ gist });
+
+    model.save().then(() => {
+      model.deleteRecord();
+    });
+  });
+});


### PR DESCRIPTION
This fixes #237. The `registerDeleteOnGist` observer isn't always called, that's the reason why deleting doesn't work properly. 
I replaced it by overriding the `deleteRecord` method on the model which calls the neccesary code.
I'm assuming the observer didn't work because `isDeleted` is a computed property which isn't consumed anywhere, I tried fixing it by calling `this.get('isDeleted')` in the init method but that didn't really fix the issue completely (it seemed to help a little, didn't test it too much though).

Anyway I think depending on the `isDeleted` flag + observer might not be the best way to accomplish this to begin with.