### PR TITLE
Cleanup Responsive Navbar Menu

### DIFF
--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -1,10 +1,12 @@
 <nav class="navbar-default">
   <div class="row toolbar">
-    <div>
-      <div class="title">
-        {{title-input value=model.description titleChanged=(action "titleChanged")}}
-        {{saved-state-indicator model=model unsaved=unsaved}}
-      </div>
+    <div class="bar">
+      {{#if media.isMobile}}
+        <div class="title">
+          {{title-input value=model.description titleChanged=(action "titleChanged")}}
+          {{saved-state-indicator model=model unsaved=unsaved}}
+        </div>
+      {{/if}}
 
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsed-menu" aria-expanded="false">
         <span class="icon-bar"></span>
@@ -13,6 +15,7 @@
       </button>
     </div>
   </div>
+
   <div id="collapsed-menu" class="collapse navbar-collapse row toolbar">
     <ul class="nav-pills main-menu">
       {{file-menu model=model
@@ -38,6 +41,13 @@
                       emberDataVersions=emberDataVersions
       }}
     </ul>
+
+    {{#if (or media.isDesktop media.isJumbo)}}
+      <div class="title">
+        {{title-input value=model.description titleChanged=(action "titleChanged")}}
+        {{saved-state-indicator model=model unsaved=unsaved}}
+      </div>
+    {{/if}}
 
     <hr>
 

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -1,6 +1,11 @@
 <nav class="navbar-default">
   <div class="row toolbar">
     <div>
+      <div class="title">
+        {{title-input value=model.description titleChanged=(action "titleChanged")}}
+        {{saved-state-indicator model=model unsaved=unsaved}}
+      </div>
+
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsed-menu" aria-expanded="false">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
@@ -34,10 +39,7 @@
       }}
     </ul>
 
-    <div class="title">
-      {{title-input value=model.description titleChanged=(action "titleChanged")}}
-      {{saved-state-indicator model=model unsaved=unsaved}}
-    </div>
+    <hr>
 
     {{user-menu session=session
                 signInViaGithub="signInViaGithub"

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -1,12 +1,10 @@
 <nav class="navbar-default">
   <div class="row toolbar">
-    <div class="bar">
-      {{#if media.isMobile}}
-        <div class="title">
-          {{title-input value=model.description titleChanged=(action "titleChanged")}}
-          {{saved-state-indicator model=model unsaved=unsaved}}
-        </div>
-      {{/if}}
+    <div>
+      <div class="title">
+        {{title-input value=model.description titleChanged=(action "titleChanged")}}
+        {{saved-state-indicator model=model unsaved=unsaved}}
+      </div>
 
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsed-menu" aria-expanded="false">
         <span class="icon-bar"></span>
@@ -41,13 +39,6 @@
                       emberDataVersions=emberDataVersions
       }}
     </ul>
-
-    {{#if (or media.isDesktop media.isJumbo)}}
-      <div class="title">
-        {{title-input value=model.description titleChanged=(action "titleChanged")}}
-        {{saved-state-indicator model=model unsaved=unsaved}}
-      </div>
-    {{/if}}
 
     <hr>
 

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -1,5 +1,9 @@
 .toolbar {
 
+  hr {
+    display: none;
+  }
+
   @media (min-width: $screen-md-min) {
     height: $topbar-height;
   }
@@ -14,6 +18,21 @@
       margin-top: 0;
       margin-bottom: 0;
     }
+
+    .nav-pills > li {
+      float: none;
+    }
+
+    .dropdown-toggle {
+      display: block;
+      border-radius: 0;
+    }
+
+    hr {
+      display: block;
+      border-color: $burnt-orange;
+      margin: 1em 0;
+    }
   }
 
   font-size: $font-size;
@@ -25,10 +44,22 @@
   box-shadow: rgba(0,0,0,0.3) 0 0 3px;
 
   button.navbar-toggle {
+    margin-top: 13px;
+    margin-bottom: 13px;
+    border-color: $burnt-orange;
+
+    @media (max-width: $screen-md-min) {
+      display: inline-block;
+    }
+
     &:hover, &:active, &:focus {
       background: $pale-orange;
       outline: none;
       opacity: 0.5;
+    }
+
+    .icon-bar {
+      background-color: $burnt-orange;
     }
   }
 
@@ -48,7 +79,12 @@
     }
 
     @media (max-width: $screen-md-min) {
-      float: right;
+      float: none;
+      text-align: left;
+
+      .user-dropdown > .dropdown-toggle {
+        padding-left: 1em;
+      }
     }
 
     .user-avatar {
@@ -73,6 +109,8 @@
   }
 
   .main-menu {
+    text-align: left;
+    height: 60px;
 
     @media (min-width: $screen-md-min) {
       position: absolute;
@@ -80,14 +118,15 @@
       top: ($topbar-height - $topbar-control-height) / 2;
     }
 
-    text-align: left;
-    height: 60px;
+    @media (max-width: $screen-md-min) {
+      height: auto;
+    }
   }
 
   .title {
     padding: 13px 0;
     text-align: center;
-    width: 100%;
+    display: inline-block;
 
     @media (min-width: $screen-md-min) {
       position: absolute;
@@ -217,6 +256,8 @@
   &.navbar-collapse {
     @media (max-width: $screen-md-min) {
       background: $ember-orange;
+      padding: 0;
+      border: 0;
     }
   }
 

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -136,6 +136,10 @@
       width: 800px;
     }
 
+    @media (max-width: $screen-md-min) {
+      margin-left: 15px;
+    }
+
     h1 {
       margin: 10px;
     }

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -4,6 +4,11 @@
     display: none;
   }
 
+  .nav-pills > li > a {
+    display: block;
+    text-decoration: none;
+  }
+
   @media (min-width: $screen-md-min) {
     height: $topbar-height;
   }

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -28,6 +28,32 @@
       border-radius: 0;
     }
 
+    .dropdown-menu {
+      position: static;
+      float: none;
+      border: 0;
+      border-radius: 0;
+      background-color: #E1563F;
+      box-shadow: none;
+
+      .dropdown-submenu > .dropdown-menu {
+        margin-left: 1em;
+        margin-top: 0;
+      }
+
+      .divider {
+        background-color: lighten($burnt-orange, 10%);
+      }
+
+      a {
+        color: #fff;
+
+        &:hover {
+          background-color: lighten($burnt-orange, 10%);
+        }
+      }
+    }
+
     hr {
       display: block;
       border-color: $burnt-orange;

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -9,6 +9,7 @@
     text-decoration: none;
   }
 
+
   @media (min-width: $screen-md-min) {
     height: $topbar-height;
   }
@@ -25,6 +26,10 @@
 
     .nav-pills > li {
       float: none;
+    }
+
+    .nav-pills > li + li {
+      margin-left: 0;
     }
 
     .dropdown-toggle {

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -19,7 +19,6 @@
     opacity: 1;
 
     >div, >ul {
-      height: $topbar-height;
       margin-top: 0;
       margin-bottom: 0;
     }

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -2,17 +2,17 @@
   File <b class="caret"></b>
 </a>
 
-<ul class="dropdown dropdown-menu">
+<ul class="dropdown-menu">
   <li>{{#link-to 'gist.new' class="test-new-twiddle" }}New Twiddle{{/link-to}}</li>
   {{#if model}}
     <li role="presentation" class="divider"></li>
-    <li class="dropdown-submenu">
+    <li class="dropdown dropdown-submenu">
       <a tabindex="-1" href="#">Add...</a>
       <ul class="dropdown-menu">
         <li><a {{action 'addFile' ''}}>Other (empty file)</a></li>
-        <li class="dropdown-submenu">
+        <li class="dropdown dropdown-submenu">
           <a {{action 'addComponent'}} class="add-component-link">Component (js and hbs)</a>
-          <ul class="'dropdown dropdown-menu">
+          <ul class="dropdown-menu">
             <li><a {{action 'addFile' 'component-hbs'}}>hbs only</a></li>
             <li><a {{action 'addFile' 'component-js'}}>js only</a></li>
           </ul>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ember-moment": "4.2.1",
     "ember-notify": "4.3.1",
     "ember-responsive": "1.2.3",
-    "ember-truth-helpers": "1.2.0",
     "ivy-codemirror": "1.3.0",
     "torii": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-moment": "4.2.1",
     "ember-notify": "4.3.1",
     "ember-responsive": "1.2.3",
+    "ember-truth-helpers": "1.2.0",
     "ivy-codemirror": "1.3.0",
     "torii": "^0.6.0"
   },


### PR DESCRIPTION
Fixes #294 

:warning: Still WIP
* Move title out of the collapsed menu
* Improve collapse button colors and position
* Make collapse menu items bigger for better mobile support
* Fix collapse menu item positioning and add break
* Fixes dropdown menu positioning and styles

## TODO

* [x] Fix navbar link sizes and underline
* [x] Fix title responsiveness (might need it in two places, ember-responsive)
* [ ] Fix dropdown toggling (currently works through hover, so broken on mobile)

![screen shot 2015-12-30 at 2 35 30 pm](https://cloud.githubusercontent.com/assets/34726/12056332/5a0faa98-af03-11e5-8dc5-c37ffbdb8548.png)
![screen shot 2015-12-30 at 2 35 09 pm](https://cloud.githubusercontent.com/assets/34726/12056330/5a0b944e-af03-11e5-9327-29a1e56f33bf.png)
![screen shot 2015-12-30 at 2 35 50 pm](https://cloud.githubusercontent.com/assets/34726/12056331/5a0fd1c6-af03-11e5-8267-0392d323a02e.png)
![screen shot 2015-12-30 at 2 41 57 pm](https://cloud.githubusercontent.com/assets/34726/12056354/8c19e634-af03-11e5-86eb-b513e53330be.png)

