### PR TITLE
add space after colon

### DIFF
--- a/blueprints/application_controller.js
+++ b/blueprints/application_controller.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  appName:'Ember Twiddle'
+  appName: 'Ember Twiddle'
 });


### PR DESCRIPTION
Minor fix to add a space after `appName:`