### PR TITLE
Add babel-plugin-htmlbars-inline-precompile to babel pipeline

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -1,9 +1,12 @@
 import Babel from "npm:babel";
 import Path from 'npm:path';
+import HtmlbarsInlinePrecompile from 'npm:babel-plugin-htmlbars-inline-precompile';
 import blueprints from '../lib/blueprints';
 import config from '../config/environment';
 import Ember from 'ember';
 import moment from 'moment';
+
+const hbsPlugin = new HtmlbarsInlinePrecompile(Ember.HTMLBars.precompile);
 
 const { inject } = Ember;
 const twiddleAppName = 'demo-app';
@@ -456,7 +459,8 @@ function babelOpts(moduleName) {
   return {
     modules:'amd',
     moduleIds:true,
-    moduleId: moduleName
+    moduleId: moduleName,
+    plugins: [ hbsPlugin ]
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "babel": "^5.0.0",
+    "babel-plugin-htmlbars-inline-precompile": "0.0.5",
     "ember-cli-sri": "2.1.0",
     "ember-cli-uglify": "1.2.0",
     "ember-data": "2.3.3",


### PR DESCRIPTION
This adds the babel plugin to the pipeline, which makes it possible to
use `import hbs from "htmlbars-inline-precompile";`. This is helpful for
writing component integration tests using ember-twiddle.

This addresses #326.

---

I tried to add a blueprint for a component test, but we can't import the one from `ember-cli` since [its' template uses `if`s](https://github.com/ember-cli/ember-cli/blob/v2.3.0/blueprints/component-test/files/tests/__testType__/__path__/__test__.js), which are [not yet supported within `ember-twiddle`](https://github.com/ember-cli/ember-twiddle/blob/v0.6.0/app/services/ember-cli.js#L158-L165)...