### PR TITLE
Get more than 30 twiddles

### DIFF
--- a/app/twiddles/route.js
+++ b/app/twiddles/route.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
   },
 
   model() {
-    return this.get('store').findAll('gist');
+    return this.get('store').query('gist', { per_page: 100 });
   },
 
   actions: {


### PR DESCRIPTION
Looks like gist.github.com is now only returning 30 gists by default. This increases that to a max of 100 gists. To do more, we will have to implement pagination.