### PR TITLE
[WIP] Addon support

### DIFF
--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -59,7 +59,7 @@ export default Ember.Service.extend({
 
   resolveAddon(name, value) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
-      let url = `https://nl1fctyzr7.execute-api.us-east-1.amazonaws.com/staging/addon?addon=${name}&addon_version=${value}&ember_version=1.13.1`;
+      let url = `https://nl1fctyzr7.execute-api.us-east-1.amazonaws.com/staging/addon?addon=${name}&addon_version=${value}&ember_version=1.13.15`;
       $.getJSON(url, function(data){
         console.log(data);
         resolve(data);

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -55,6 +55,7 @@ export default Ember.Service.extend({
         if(addon.status === 'build_success') {
           dependencies[name] = addon.addon_js;
           dependencies[name+'_css'] = addon.addon_css;
+          console.log(`Addon ${name} is loaded...`);
         }
         else if (addon.status === 'building') {
           console.log(`Addon ${name} is currently building...`);

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -54,6 +54,7 @@ export default Ember.Service.extend({
         let addon = hash[name];
         if(addon.status === 'build_success') {
           dependencies[name] = addon.addon_js;
+          dependencies[name+'_css'] = addon.addon_css;
         }
         else if (addon.status === 'building') {
         }

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -57,8 +57,13 @@ export default Ember.Service.extend({
           dependencies[name+'_css'] = addon.addon_css;
         }
         else if (addon.status === 'building') {
+          console.log(`Addon ${name} is currently building...`);
+          console.log(`Joost will have to implement some sort of refresh logic here..`);
         }
         else if (addon.status === 'build_error') {
+          console.error(`Addon ${name} encountered a build error:`);
+          console.error(addon.errors, addon.ember_errors);
+          console.log(`Joost will have to implement some sort of error logic here..`);
         }
       });
     });

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -52,7 +52,13 @@ export default Ember.Service.extend({
     return Ember.RSVP.hash(addonPromises).then(hash => {
       Object.keys(addons).forEach((name) => {
         let addon = hash[name];
-        dependencies[name] = `https://s3.amazonaws.com/addons-test/${addon.addon_js}`
+        if(addon.status === 'build_success') {
+          dependencies[name] = addon.addon_js;
+        }
+        else if (addon.status === 'building') {
+        }
+        else if (addon.status === 'build_error') {
+        }
       });
     });
   },
@@ -61,7 +67,6 @@ export default Ember.Service.extend({
     return new Ember.RSVP.Promise(function(resolve, reject) {
       let url = `https://nl1fctyzr7.execute-api.us-east-1.amazonaws.com/staging/addon?addon=${name}&addon_version=${value}&ember_version=1.13.15`;
       $.getJSON(url, function(data){
-        console.log(data);
         resolve(data);
       });
     });

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -41,6 +41,32 @@ export default Ember.Service.extend({
     });
   },
 
+  resolveAddons: function(addons, dependencies) {
+    let addonPromises = {};
+    Object.keys(addons).forEach((name) => {
+      var value = addons[name];
+
+      addonPromises[name] = this.resolveAddon(name, value);
+    });
+
+    return Ember.RSVP.hash(addonPromises).then(hash => {
+      Object.keys(addons).forEach((name) => {
+        let addon = hash[name];
+        dependencies[name] = `https://s3.amazonaws.com/addons-test/${addon.addon_js}`
+      });
+    });
+  },
+
+  resolveAddon(name, value) {
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      let url = `https://nl1fctyzr7.execute-api.us-east-1.amazonaws.com/staging/addon?addon=${name}&addon_version=${value}&ember_version=1.13.1`;
+      $.getJSON(url, function(data){
+        console.log(data);
+        resolve(data);
+      });
+    });
+  },
+
   resolveDependency: function(name, value) {
     switch (name) {
       case 'ember':

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -358,6 +358,9 @@ export default Ember.Service.extend({
           resolve(twiddleJson);
         });
       }
+      else {
+        resolve(twiddleJson);
+      }
     });
   },
 

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -353,10 +353,11 @@ export default Ember.Service.extend({
 
       var dependencyResolver = this.get('dependencyResolver');
       dependencyResolver.resolveDependencies(twiddleJson.dependencies);
-      dependencyResolver.resolveAddons(twiddleJson.addons, twiddleJson.dependencies).then(() => {
-        console.log(twiddleJson);
-        resolve(twiddleJson);
-      });
+      if ('addons' in twiddleJson) {
+        dependencyResolver.resolveAddons(twiddleJson.addons, twiddleJson.dependencies).then(() => {
+          resolve(twiddleJson);
+        });
+      }
     });
   },
 

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -264,7 +264,7 @@ export default Ember.Service.extend({
       let dep = deps[depKey];
       if (dep.substr(dep.lastIndexOf(".")) === '.css') {
         depCssLinkTags += `<link rel="stylesheet" type="text/css" href="${dep}">`;
-      } else {
+      } else if (dep.substr(dep.lastIndexOf(".")) === '.js') {
         depScriptTags += `<script type="text/javascript" src="${dep}"></script>`;
       }
     });


### PR DESCRIPTION
**VERY WIP**

Adds support for using addons in `twiddle.json` like this:
```json
{
  "addons": {
    "ember-tooltips": "latest"
  }
}
```

This works by requesting a combo of addon + addon version + ember version from an API which in turn redirects to an S3 bucket where the built addons are stored. If the addon is not built yet, it will trigger a build in the background (using lambda).

Build process:
- https://github.com/joostdevries/twiddle-backend/blob/master/addon-builder/ember-blueprints/1.13.15/ember-cli-build.js
- https://github.com/joostdevries/twiddle-backend/blob/master/addon-builder/index.js

Features:
- Will use NPM version resolving (so you can use "latests" or semver logic in `twiddle.json`)
- Will try to build the addon if it's not in our S3 bucket yet
- Will include both CSS + JS
- Will include app, addon and vendor JS + CSS

Todo
- [ ] A nice message while we're building
- [ ] A nice error message if the build failed
- [ ] Support multiple ember versions
- [ ] Backend fixes
  - [x] The current broccoli logic is a huge pile of hackery. Need to clean that up.
  - [x] Currently, we include more into the build then desired, for example we somehow include test assets in the liquid-fire build.
  - [ ] Support bower deps