### PR TITLE
Make dependencies order chronologically.

### DIFF
--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -28,7 +28,7 @@ const CHANNEL_FILENAME_MAP = {
   'ember-data': 'ember-data.js'
 };
 
-const CHANNELS = ['release', 'beta', 'canary'];
+const CHANNELS = ['canary', 'beta', 'release'];
 
 const { computed, RSVP } = Ember;
 


### PR DESCRIPTION
Previously, the dependencies were ordered like:

<img width="571" alt="screen shot 2016-03-28 at 13 59 57" src="https://cloud.githubusercontent.com/assets/12637/14085562/8fae06a0-f4ee-11e5-99db-9b869f56c494.png">

After this change, the following order is used:

<img width="496" alt="screen shot 2016-03-28 at 14 00 53" src="https://cloud.githubusercontent.com/assets/12637/14085572/9c876556-f4ee-11e5-9cb6-b42437e568cb.png">
