### PR TITLE
fixed header position typo

### DIFF
--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -73,7 +73,7 @@
   font-size: $font-size;
   background: $ember-orange;
   background-image: url(/images/header.svg);
-  background-position: top-center;
+  background-position: top center;
   background-repeat: no-repeat;
   background-size: cover;
   padding: 1rem 0;


### PR DESCRIPTION
typo causes image not to show up when CSS is minified and background properties are combined