### PR TITLE
[WIP] Update to ember-cli#canary to test baseURL removal.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,8 +11,8 @@
 
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="stylesheet" href="loader.css">
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/ember-twiddle.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/ember-twiddle.css">
     <link href='//fonts.googleapis.com/css?family=Maven+Pro:400,500,700' rel='stylesheet' type='text/css'>
 
     {{content-for 'head-footer'}}
@@ -28,8 +28,8 @@
     <div id="app">
     </div>
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/ember-twiddle.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/ember-twiddle.js"></script>
 
     {{content-for 'body-footer'}}
 

--- a/app/router.js
+++ b/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'ember-twiddle',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     host: 'https://api.github.com',
     githubOauthUrl: 'http://localhost:9999/authenticate/',
@@ -48,7 +48,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
-    ENV.baseURL = '/';
     ENV.locationType = 'auto';
 
     // keep test console output quieter

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-api-actions": "0.1.3",
     "ember-autoresize": "0.5.16",
     "ember-browserify": "1.1.8",
-    "ember-cli": "2.6.0-beta.2",
+    "ember-cli": "ember-cli/ember-cli#canary",
     "ember-cli-app-version": "1.0.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-bootstrap-sassy": "0.5.3",

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/ember-twiddle.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/ember-twiddle.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}
@@ -28,11 +28,11 @@
     {{content-for "test-body"}}
 
     <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/ember-twiddle.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/ember-twiddle.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
As a follow-up for http://emberjs.com/blog/2016/04/28/baseURL.html, this
updates ember-twiddle to use canary ember-cli to ensure things are
working properly and allow ember-twiddle to be up to date once 2.7 rolls
into beta.

This is not intended to be merged until ember-cli@2.7.0-beta.1 is
released.