### PR TITLE
Add ability to copy gist revision to new gist

### DIFF
--- a/app/components/file-menu.js
+++ b/app/components/file-menu.js
@@ -7,8 +7,11 @@ export default Ember.Component.extend(DropdownSubmenuFixMixin, {
   tagName: 'li',
   classNames: ['dropdown'],
 
-  belongsToUser: computed('model.ownerLogin', 'session.currentUser.login', function() {
-    return this.get('model.ownerLogin') === this.get('session.currentUser.login');
+  // show fork option only if does not belong to user and is not a revision, otherwise show copy
+  // Github api does not permit forking if you own the gist already
+  // Github does not provide api for forking a revision
+  showFork: computed('model.ownerLogin', 'session.currentUser.login', 'isRevision', function() {
+    return !this.get('isRevision') && this.get('model.ownerLogin') !== this.get('session.currentUser.login');
   }),
 
   actions: {

--- a/app/gist/edit/revision/copy/route.js
+++ b/app/gist/edit/revision/copy/route.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect: function() {
+    this.transitionTo('gist.new', {
+      queryParams: {
+        copyCurrentTwiddle: true
+      }
+    });
+  }
+});

--- a/app/gist/edit/revision/route.js
+++ b/app/gist/edit/revision/route.js
@@ -15,5 +15,12 @@ export default GistEditRoute.extend({
     }).then((response) => {
       return response.get('firstObject');
     });
-  }
+  },
+
+  setupController(...args) {
+    this._super(...args);
+
+    const gistController = this.controllerFor('gist');
+    gistController.set('isRevision', true);
+  },
 });

--- a/app/gist/template.hbs
+++ b/app/gist/template.hbs
@@ -7,6 +7,7 @@
             route=route
             applicationUrl=applicationUrl
             unsaved=unsaved
+            isRevision=isRevision
             transitionQueryParams=(action "transitionQueryParams")
             titleUpdated=(route-action "titleUpdated")
 }}

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -57,11 +57,11 @@
       {{#unless model.isNew}}
         <li><a {{action 'share'}}>Share Twiddle</a></li>
         <li><a {{action 'embed'}}>Embed Twiddle</a></li>
-        {{#unless belongsToUser}}
+        {{#if showFork}}
           <li><a {{action 'fork' model}} class="test-fork-action">Fork Twiddle</a></li>
         {{else}}
           <li><a {{action 'copy'}} class="test-copy-action">Copy Twiddle</a></li>
-        {{/unless}}
+        {{/if}}
         <li><a {{action 'deleteGist' model}} class="test-delete-action">Delete Twiddle</a></li>
       {{/unless}}
     {{else}}

--- a/app/templates/components/gist-header.hbs
+++ b/app/templates/components/gist-header.hbs
@@ -20,6 +20,7 @@
                   session=session
                   activeEditorCol=activeEditorCol
                   activeFile=activeFile
+                  isRevision=isRevision
                   addFile=(action this.attrs.addFile)
                   addHelper=(action this.attrs.addHelper)
                   addComponent=(action this.attrs.addComponent)

--- a/app/templates/components/main-gist.hbs
+++ b/app/templates/components/main-gist.hbs
@@ -3,6 +3,7 @@
               unsaved=unsaved
               activeEditorCol=activeEditorCol
               activeFile=activeFile
+              isRevision=isRevision
               titleChanged=(action "titleChanged")
               addFile=(action "addFile")
               addHelper=(action "addHelper")

--- a/tests/acceptance/git-revision-test.js
+++ b/tests/acceptance/git-revision-test.js
@@ -1,7 +1,17 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'ember-twiddle/tests/helpers/module-for-acceptance';
+import { stubValidSession } from 'ember-twiddle/tests/helpers/torii';
 
-moduleForAcceptance('Acceptance | gist-revision');
+moduleForAcceptance('Acceptance | gist-revision', {
+  beforeEach: function() {
+    this.cacheConfirm = window.confirm;
+    window.confirm = () => true;
+  },
+
+  afterEach: function() {
+    window.confirm = this.cacheConfirm;
+  }
+});
 
 test('Able to load a previous revision of a gist', function(assert) {
 
@@ -18,5 +28,42 @@ test('Able to load a previous revision of a gist', function(assert) {
     const outputDiv = 'div';
 
     assert.equal(outputContents(outputDiv), 'Hello, World!', 'Previous version of a gist is displayed');
+  });
+});
+
+test('Able to copy a revision into new gist', function(assert) {
+  // set owner of gist as currently logged in user
+  stubValidSession(this.application, {
+    currentUser: { login: "Gaurav0" },
+    "github-oauth2": {}
+  });
+
+  runRevision([
+    {
+      filename: 'application.template.hbs',
+      content: 'hello world!'
+    }
+  ]);
+
+  andThen(function() {
+    assert.equal(find('.test-unsaved-indicator').length, 0, "No unsaved indicator shown");
+  });
+
+  fillIn('.title input', "my twiddle");
+  andThen(function() {
+    assert.equal(find('.title input').val(), "my twiddle");
+  });
+
+  click('.test-copy-action');
+
+  andThen(function() {
+    waitForLoadedIFrame();
+  });
+
+  andThen(function() {
+    assert.equal(find('.title input').val(), "New Twiddle", "Description is reset");
+    assert.equal(find('.test-unsaved-indicator').length, 0, "Unsaved indicator does not appear when gist is copied");
+    assert.equal(find('.test-copy-action').length, 0, "Menu item to copy gist is not shown anymore");
+    assert.equal(outputContents('div'), 'hello world!');
   });
 });


### PR DESCRIPTION
This adds the ability to copy a previous revision of an existing gist, yours or not, into a new gist.

This also removes the fork option for gist revisions, as Github does not provide the ability to fork from a previous revision of a gist.