### PR TITLE
Use custom model blueprint

### DIFF
--- a/blueprints/model.js
+++ b/blueprints/model.js
@@ -1,0 +1,6 @@
+import Model from "ember-data/model";
+import attr from "ember-data/attr";
+import { belongsTo, hasMany } from "ember-data/relationships";
+
+export default Model.extend({
+});

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -142,7 +142,6 @@ function getEmberCLIBlueprints() {
         'component-hbs': 'component/files/__root__/__templatepath__/__templatename__.hbs',
         'component-js': 'component/files/__root__/__path__/__name__.js',
         'controller': 'controller/files/__root__/__path__/__name__.js',
-        'model': 'model/files/__root__/__path__/__name__.js',
         'route': 'route/files/__root__/__path__/__name__.js',
         'service': 'service/files/__root__/__path__/__name__.js',
         'template': 'template/files/__root__/__path__/__name__.hbs',
@@ -177,6 +176,7 @@ function getEmberCLIBlueprints() {
   fileMap['app.css'] = fs.readFileSync('blueprints/app.css').toString();
   fileMap['index.html'] = fs.readFileSync('blueprints/index.html').toString();
   fileMap['test-start-app'] = fs.readFileSync('blueprints/start-app.js').toString();
+  fileMap['model'] = fs.readFileSync('blueprints/model.js').toString();
 
   return 'export default ' + JSON.stringify(fileMap);
 }


### PR DESCRIPTION
Since the model blueprint from ember-cli-legacy-blueprints contains
custom logic for the import statements in the blueprints' index.js and
ember-twiddle doesn't support this (yet), we create our own model
blueprint inside ember-twiddle.

---

The currently generated model file using the blueprint from
ember-cli-legacy-blueprints looks like this (note the lacking import
for `Model`):

```js

export default Model.extend({
});
```