### PR TITLE
Fix codemirror options

### DIFF
--- a/app/templates/components/file-editor-column.hbs
+++ b/app/templates/components/file-editor-column.hbs
@@ -44,13 +44,14 @@
 
 {{#if file}}
 {{ivy-codemirror
-    value         = file.content
-    mode          = editorMode
-    keyMap        = keyMap
-    lineNumbers   = true
-    fixedGutter   = true
-    lineWrapping  = true
-    tabSize       = 2
-    valueUpdated  = "valueUpdated"
+    value=file.content
+    options=(hash
+      mode=editorMode
+      keyMap=keyMap
+      lineNumbers=true
+      fixedGutter=true
+      lineWrapping=true
+      tabSize=2)
+    valueUpdated="valueUpdated"
 }}
 {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "ember-qunit-notifications": "0.1.0",
     "jquery": "1.11.3",
     "codemirror": "~5.15.2",
-    "ember-cli-codemirror-shim": "~0.0.1",
     "bootstrap-sass": "~3.3.5",
     "dom-ruler": "0.1.13",
     "pretender": "~1.1.0",


### PR DESCRIPTION
Codemirror options are now specified via hash instead of individual properties since ivy-codemirror 2.0. This broke features.