### PR TITLE
Fix integration tests broken by upgrade to Ember 2.7

### DIFF
--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -18,6 +18,11 @@ const CDN_MAP = {
     fileName: 'ember-template-compiler.js'
   },
 
+  'ember-testing': {
+    library: 'ember.js',
+    fileName: 'ember-testing.js'
+  },
+
   'ember-data': {
     library: 'ember-data.js',
     fileName: 'ember-data.js'
@@ -27,6 +32,7 @@ const CDN_MAP = {
 const CHANNEL_FILENAME_MAP = {
   'ember': 'ember.debug.js',
   'ember-template-compiler': 'ember-template-compiler.js',
+  'ember-testing': 'ember-testing.js',
   'ember-data': 'ember-data.js'
 };
 
@@ -102,6 +108,7 @@ export default Ember.Service.extend({
     switch (name) {
       case 'ember':
       case 'ember-template-compiler':
+      case 'ember-testing':
       case 'ember-data':
         return this.resolveEmberDependency(name, value);
 

--- a/app/services/twiddle-json.js
+++ b/app/services/twiddle-json.js
@@ -6,7 +6,13 @@ const { inject, RSVP } = Ember;
 const requiredDependencies = [
   'jquery',
   'ember',
-  'ember-template-compiler'
+  'ember-template-compiler',
+  'ember-testing'
+];
+
+const dependentDependencies = [
+  'ember-template-compiler',
+  'ember-testing'
 ];
 
 export default Ember.Service.extend({
@@ -44,8 +50,8 @@ export default Ember.Service.extend({
       const dependencies = JSON.parse(blueprints['twiddle.json']).dependencies;
       requiredDependencies.forEach(function(dep) {
         if (!twiddleJson.dependencies[dep] && dependencies[dep]) {
-          if (dep === 'ember-template-compiler') {
-            twiddleJson.dependencies[dep] = twiddleJson.dependencies['ember'].replace('ember.debug.js', 'ember-template-compiler.js');
+          if (dependentDependencies.includes(dep)) {
+            twiddleJson.dependencies[dep] = twiddleJson.dependencies['ember'].replace('ember.debug.js', dep + '.js');
           } else {
             twiddleJson.dependencies[dep] = dependencies[dep];
           }
@@ -94,8 +100,12 @@ export default Ember.Service.extend({
       // since ember and ember-template-compiler should always have the same
       // version, we update the version for the ember-template-compiler too, if
       // the ember dependency is updated
-      if (dependencyName === 'ember' && json.dependencies.hasOwnProperty('ember-template-compiler')) {
-        json.dependencies['ember-template-compiler'] = version;
+      if (dependencyName === 'ember') {
+        dependentDependencies.forEach((dep) => {
+          if (json.dependencies.hasOwnProperty(dep)) {
+            json.dependencies[dep] = version;
+          }
+        });
       }
 
       return json;

--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -11,7 +11,8 @@
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
     "ember": "2.7.0",
     "ember-data": "2.7.0",
-    "ember-template-compiler": "2.7.0"
+    "ember-template-compiler": "2.7.0",
+    "ember-testing": "2.7.0"
   },
   "addons": {}
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -68,7 +68,8 @@ module.exports = function(defaults) {
     vendorFiles: {
       'ember.js': {
         staging:  'bower_components/ember/ember.prod.js'
-      }
+      },
+      'ember-testing.js': null
     }
   });
 
@@ -82,6 +83,10 @@ module.exports = function(defaults) {
   }
 
   app.import('bower_components/ember/ember-template-compiler.js');
+
+  if (env === "test") {
+    app.import('bower_components/ember/ember-testing.js', { type: 'test' });
+  }
 
   if (!isFastboot) {
     app.import('vendor/drags.js');

--- a/tests/acceptance/addons-test.js
+++ b/tests/acceptance/addons-test.js
@@ -42,8 +42,7 @@ test('Addons work', function(assert) {
                   "dependencies": {
                     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
                     "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.4.3/ember.debug.js",
-                    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/2.4.2/ember-data.js",
-                    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.4.3/ember-template-compiler.js"
+                    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/2.4.2/ember-data.js"
                   },
                   "addons": {
                     "ember-truth-helpers": "1.2.0"

--- a/tests/acceptance/routing-test.js
+++ b/tests/acceptance/routing-test.js
@@ -68,7 +68,8 @@ const TWIDDLE_WITH_ROUTES = [
                   "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
                   "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember.debug.js",
                   "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.13.13/ember-data.js",
-                  "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js"
+                  "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-template-compiler.js",
+                  "ember-testing": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.10/ember-testing.js"
                 }
               }`
   }

--- a/tests/acceptance/use-pods-test.js
+++ b/tests/acceptance/use-pods-test.js
@@ -45,8 +45,7 @@ test('Use pods option works', function(assert) {
                   "dependencies": {
                     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
                     "ember": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.4.3/ember.debug.js",
-                    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/2.4.0/ember-data.js",
-                    "ember-template-compiler": "https://cdnjs.cloudflare.com/ajax/libs/ember.js/2.4.3/ember-template-compiler.js"
+                    "ember-data": "https://cdnjs.cloudflare.com/ajax/libs/ember-data.js/2.4.0/ember-data.js"
                   }
                 }`
     }

--- a/tests/unit/services/dependency-resolver-test.js
+++ b/tests/unit/services/dependency-resolver-test.js
@@ -9,6 +9,7 @@ test('resolveDependencies() leaves URLs untouched', function(assert) {
     jquery: '//my-cdn.com/1.2.3/jquery.js',
     ember: 'https://my-cdn.com/1.2.3/ember.js',
     'ember-template-compiler': '//my-cdn.com/1.2.3/ember-template-compiler.js',
+    'ember-testing': '//another-cdn.com/1.2.3/ember-testing.js',
     'ember-data': '//my-cdn.com/1.2.3/ember-data.js'
   };
 
@@ -18,6 +19,7 @@ test('resolveDependencies() leaves URLs untouched', function(assert) {
     jquery: '//my-cdn.com/1.2.3/jquery.js',
     ember: 'https://my-cdn.com/1.2.3/ember.js',
     'ember-template-compiler': '//my-cdn.com/1.2.3/ember-template-compiler.js',
+    'ember-testing': '//another-cdn.com/1.2.3/ember-testing.js',
     'ember-data': '//my-cdn.com/1.2.3/ember-data.js'
   });
 });
@@ -64,6 +66,20 @@ test('it resolves version for ember-template-compiler', function(assert) {
   });
 });
 
+test('it resolves version for ember-testing', function(assert) {
+  var service = this.subject();
+
+  var dependencies = {
+    'ember-testing': '1.12.1'
+  };
+
+  service.resolveDependencies(dependencies);
+
+  assert.deepEqual(dependencies, {
+    'ember-testing': '//cdnjs.cloudflare.com/ajax/libs/ember.js/1.12.1/ember-testing.js'
+  });
+});
+
 test('it resolves version for ember-data', function(assert) {
   var service = this.subject();
 
@@ -84,6 +100,7 @@ test('release channel can be specified for version', function(assert) {
   var dependencies = {
     'ember': 'release',
     'ember-template-compiler': 'release',
+    'ember-testing': 'release',
     'ember-data': 'release',
   };
 
@@ -92,6 +109,7 @@ test('release channel can be specified for version', function(assert) {
   assert.deepEqual(dependencies, {
     'ember': '//s3.amazonaws.com/builds.emberjs.com/release/ember.debug.js',
     'ember-template-compiler': '//s3.amazonaws.com/builds.emberjs.com/release/ember-template-compiler.js',
+    'ember-testing': '//s3.amazonaws.com/builds.emberjs.com/release/ember-testing.js',
     'ember-data': '//s3.amazonaws.com/builds.emberjs.com/release/ember-data.js'
   });
 });
@@ -102,6 +120,7 @@ test('beta channel can be specified for version', function(assert) {
   var dependencies = {
     'ember': 'beta',
     'ember-template-compiler': 'beta',
+    'ember-testing': 'beta',
     'ember-data': 'beta',
   };
 
@@ -110,6 +129,7 @@ test('beta channel can be specified for version', function(assert) {
   assert.deepEqual(dependencies, {
     'ember': '//s3.amazonaws.com/builds.emberjs.com/beta/ember.debug.js',
     'ember-template-compiler': '//s3.amazonaws.com/builds.emberjs.com/beta/ember-template-compiler.js',
+    'ember-testing': '//s3.amazonaws.com/builds.emberjs.com/beta/ember-testing.js',
     'ember-data': '//s3.amazonaws.com/builds.emberjs.com/beta/ember-data.js'
   });
 });
@@ -120,6 +140,7 @@ test('canary channel can be specified for version', function(assert) {
   var dependencies = {
     'ember': 'canary',
     'ember-template-compiler': 'canary',
+    'ember-testing': 'canary',
     'ember-data': 'canary',
   };
 
@@ -128,6 +149,7 @@ test('canary channel can be specified for version', function(assert) {
   assert.deepEqual(dependencies, {
     'ember': '//s3.amazonaws.com/builds.emberjs.com/canary/ember.debug.js',
     'ember-template-compiler': '//s3.amazonaws.com/builds.emberjs.com/canary/ember-template-compiler.js',
+    'ember-testing': '//s3.amazonaws.com/builds.emberjs.com/canary/ember-testing.js',
     'ember-data': '//s3.amazonaws.com/builds.emberjs.com/canary/ember-data.js'
   });
 });
@@ -138,6 +160,7 @@ test('alpha channel can be specified for version', function(assert) {
   var dependencies = {
     'ember': 'alpha',
     'ember-template-compiler': 'alpha',
+    'ember-testing': 'alpha',
     'ember-data': 'alpha',
   };
 
@@ -146,6 +169,7 @@ test('alpha channel can be specified for version', function(assert) {
   assert.deepEqual(dependencies, {
     'ember': '//s3.amazonaws.com/builds.emberjs.com/alpha/ember.debug.js',
     'ember-template-compiler': '//s3.amazonaws.com/builds.emberjs.com/alpha/ember-template-compiler.js',
+    'ember-testing': '//s3.amazonaws.com/builds.emberjs.com/alpha/ember-testing.js',
     'ember-data': '//s3.amazonaws.com/builds.emberjs.com/alpha/ember-data.js'
   });
 });

--- a/tests/unit/services/twiddle-json-test.js
+++ b/tests/unit/services/twiddle-json-test.js
@@ -30,6 +30,7 @@ test("getTwiddleJson() resolves dependencies", function(assert) {
     assert.deepEqual(twiddleJson.dependencies, {
       'ember': "//cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.9/ember.debug.js",
       'ember-template-compiler': "//cdnjs.cloudflare.com/ajax/libs/ember.js/2.0.1/ember-template-compiler.js",
+      'ember-testing': "//cdnjs.cloudflare.com/ajax/libs/ember.js/1.13.9/ember-testing.js",
       'ember-data': "//cdnjs.cloudflare.com/ajax/libs/ember-data.js/1.12.1/ember-data.js",
       'jquery': "//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"
     });
@@ -88,5 +89,33 @@ test("updateDependencyVersion() updates the version of ember-template-compiler i
 
     assert.equal(parsed.dependencies.ember, 'release');
     assert.equal(parsed.dependencies['ember-template-compiler'], 'release');
+  });
+});
+
+test("updateDependencyVersion() updates the version of ember-testing if ember is updated", function(assert) {
+  assert.expect(2);
+
+  var service = this.subject();
+
+  var gist = Ember.Object.create({
+    files: Ember.A([Ember.Object.create({
+      filePath: 'twiddle.json',
+      content: `
+        {
+          "dependencies": {
+            "ember": "1.13.9",
+            "ember-testing": "1.13.9"
+          }
+        }
+      `
+    })])
+  });
+
+  service.updateDependencyVersion(gist, 'ember', 'release').then(function() {
+    var updatedContent = gist.get('files').findBy('filePath', 'twiddle.json').get('content');
+    var parsed = JSON.parse(updatedContent);
+
+    assert.equal(parsed.dependencies.ember, 'release');
+    assert.equal(parsed.dependencies['ember-testing'], 'release');
   });
 });


### PR DESCRIPTION
The idea here is to use the same version of ember-testing.js as ember.js, just like with ember-template-compiler.js

Fixes #468