### PR TITLE
Twiddle testing

### DIFF
--- a/app/components/main-gist.js
+++ b/app/components/main-gist.js
@@ -76,6 +76,8 @@ export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin,
    */
   fileTreeShown: true,
 
+  testsEnabled: Ember.computed.oneWay('emberCli.enableTesting'),
+
   /**
    * reinitialize component when the model has changed
    */
@@ -238,6 +240,11 @@ export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin,
       const settings = this.get('settings');
       settings.set('keyMap', keyMap);
       settings.save();
+    },
+
+    switchTests(testsEnabled) {
+      this.get('emberCli').setTesting(this.get('model'), testsEnabled);
+      this.get('rebuildApp').perform();
     }
   }
 });

--- a/app/components/main-gist.js
+++ b/app/components/main-gist.js
@@ -5,7 +5,7 @@ import FilesMixin from "../mixins/files";
 import TestFilesMixin from "../mixins/test-files";
 import AppBuilderMixin from "../mixins/app-builder";
 
-const { inject } = Ember;
+const { inject, computed } = Ember;
 
 export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin, TestFilesMixin, {
   emberCli: inject.service('ember-cli'),
@@ -18,8 +18,8 @@ export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin,
   fullScreen: false,
   openFiles: "",
 
-  init(...args) {
-    this._super(...args);
+  init() {
+    this._super(...arguments);
     this.set('settings', Settings.create({
       isFastBoot: this.get('fastboot.isFastBoot')
     }));
@@ -76,13 +76,13 @@ export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin,
    */
   fileTreeShown: true,
 
-  testsEnabled: Ember.computed.oneWay('emberCli.enableTesting'),
+  testsEnabled: computed.oneWay('emberCli.enableTesting'),
 
   /**
    * reinitialize component when the model has changed
    */
   didReceiveAttrs() {
-    this._super.apply(this, arguments);
+    this._super(...arguments);
 
     const model = this.get('model');
 

--- a/app/components/main-gist.js
+++ b/app/components/main-gist.js
@@ -243,6 +243,11 @@ export default Ember.Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin,
     },
 
     switchTests(testsEnabled) {
+      this.ensureTestHelperExists();
+      this.ensureTestResolverExists();
+      this.ensureTestStartAppHelperExists();
+      this.ensureTestDestroyAppHelperExists();
+
       this.get('emberCli').setTesting(this.get('model'), testsEnabled);
       this.get('rebuildApp').perform();
     }

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -219,7 +219,14 @@ export default Ember.Service.extend({
         this.addConfig(out, gist, twiddleJSON);
 
         // Add boot code
-        contentForAppBoot(out, { modulePrefix: twiddleAppName, dependencies: twiddleJSON.dependencies, twiddleJSON });
+        contentForAppBoot(
+          out,
+          {
+            modulePrefix: twiddleAppName,
+            dependencies: twiddleJSON.dependencies,
+            testingEnabled: testingEnabled(twiddleJSON)
+          }
+        );
 
         return RSVP.resolve(this.buildHtml(gist, out.join('\n'), cssOut.join('\n'), twiddleJSON));
       }));
@@ -473,7 +480,7 @@ function contentForAppBoot (content, config) {
     content.push('  require("'+mod+'").__esModule=true;');
   });
 
-  if (!testingEnabled(config.twiddleJSON)) {
+  if (!config.testingEnabled) {
     content.push('  require("' +
       config.modulePrefix +
       '/app")["default"].create(' +

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -157,6 +157,7 @@ export default Ember.Service.extend({
   twiddleJson: inject.service(),
 
   usePods: computed.readOnly('twiddleJson.usePods'),
+  enableTesting: false,
 
   setup(gist) {
     this.get('twiddleJson').setup(gist);
@@ -217,6 +218,7 @@ export default Ember.Service.extend({
       resolve(this.get('twiddleJson').getTwiddleJson(gist).then(twiddleJSON => {
 
         this.addConfig(out, gist, twiddleJSON);
+        this.set('enableTesting', testingEnabled(twiddleJSON));
 
         // Add boot code
         contentForAppBoot(
@@ -439,6 +441,10 @@ export default Ember.Service.extend({
         "import $1 from $2twiddle/");
     });
     return code;
+  },
+
+  setTesting(gist, enabled = true) {
+    this.get('twiddleJson').setTesting(gist, enabled);
   }
 });
 

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -226,7 +226,8 @@ export default Ember.Service.extend({
           {
             modulePrefix: twiddleAppName,
             dependencies: twiddleJSON.dependencies,
-            testingEnabled: testingEnabled(twiddleJSON)
+            testingEnabled: testingEnabled(twiddleJSON),
+            legacyTesting: legacyTesting(twiddleJSON)
           }
         );
 
@@ -284,7 +285,7 @@ export default Ember.Service.extend({
 
     let contentForBody = `${depScriptTags}\n${appScriptTag}\n${testStuff}\n`;
 
-    if (!testingEnabled(twiddleJSON)) {
+    if (!testingEnabled(twiddleJSON) || legacyTesting(twiddleJSON)) {
       contentForBody += '<div id="root"></div>';
     }
 
@@ -486,7 +487,7 @@ function contentForAppBoot (content, config) {
     content.push('  require("'+mod+'").__esModule=true;');
   });
 
-  if (!config.testingEnabled) {
+  if (!config.testingEnabled || config.legacyTesting) {
     content.push('  require("' +
       config.modulePrefix +
       '/app")["default"].create(' +
@@ -506,4 +507,8 @@ function calculateAppConfig(config) {
 
 function testingEnabled(twiddleJSON) {
   return twiddleJSON && twiddleJSON.options && twiddleJSON.options["enable-testing"];
+}
+
+function legacyTesting(twiddleJSON) {
+  return twiddleJSON && twiddleJSON.options && twiddleJSON.options["legacy-testing"];
 }

--- a/app/services/twiddle-json.js
+++ b/app/services/twiddle-json.js
@@ -113,11 +113,15 @@ export default Ember.Service.extend({
   },
 
   ensureTestingEnabled(gist) {
+    return this.setTesting(gist, true);
+  },
+
+  setTesting(gist, enabled = true) {
     return this._updateTwiddleJson(gist, (json) => {
       if (!json.options) {
         json.options = {};
       }
-      json.options["enable-testing"] = true;
+      json.options["enable-testing"] = enabled;
       return json;
     });
   }

--- a/app/styles/_output-pane.scss
+++ b/app/styles/_output-pane.scss
@@ -35,3 +35,11 @@
     height: 100%;
   }
 }
+
+.twiddle-run-tests {
+  position: absolute;
+  right: 106px;
+  top: 10px;
+  margin: 10px 25px;
+  text-align: right;
+}

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -3,8 +3,8 @@
     {{#if fileTreeShown}}
       <div class="col-md-4 file-tree">
         {{file-tree model=model
-                    openFile=(action this.attrs.openFile)
-                    hideFileTree=(action this.attrs.hideFileTree)
+                    openFile=(action this.openFile)
+                    hideFileTree=(action this.hideFileTree)
         }}
       </div>
     {{/if}}
@@ -18,12 +18,12 @@
                                keyMap=settings.keyMap
                                numColumns=numColumns
                                fileTreeShown=fileTreeShown
-                               focusEditor=(action this.attrs.focusEditor)
-                               selectFile=(action this.attrs.selectFile)
-                               contentChanged=(action this.attrs.updateColumn)
-                               removeColumn=(action this.attrs.removeColumn)
-                               addColumn=(action this.attrs.addColumn)
-                               showFileTree=(action this.attrs.showFileTree)
+                               focusEditor=(action this.focusEditor)
+                               selectFile=(action this.selectFile)
+                               contentChanged=(action this.updateColumn)
+                               removeColumn=(action this.removeColumn)
+                               addColumn=(action this.addColumn)
+                               showFileTree=(action this.showFileTree)
           }}
         </div>
       {{/if}}
@@ -33,7 +33,7 @@
   <div class="col-md-4 output {{if fullScreen 'full-screen'}}">
     <div class="header">
       {{#if noColumns}}
-        <span class="glyphicon glyphicon-plus" {{action (action this.attrs.addColumn)}} title="Show an editor panel"></span>
+        <span class="glyphicon glyphicon-plus" {{action (action this.addColumn)}} title="Show an editor panel"></span>
       {{/if}}
       {{build-messages notify=notify
                        isBuilding=isBuilding
@@ -41,10 +41,10 @@
       }}
     </div>
     <label class="checkbox-inline twiddle-run-tests">
-      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
+      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.switchTests)}}
       Run Tests
     </label>
-    {{run-or-live-reload liveReloadChanged=(action this.attrs.liveReloadChanged) runNow=(action this.attrs.runNow)}}
+    {{run-or-live-reload liveReloadChanged=(action this.liveReloadChanged) runNow=(action this.runNow)}}
     <div class="url-bar">
       {{input value=applicationUrl enter=(route-action "urlChanged")}}
     </div>
@@ -53,7 +53,7 @@
     {{/if}}
     {{dummy-app html=buildOutput isBuilding=isBuilding}}
     {{#if fullScreen}}
-      <a class="exit-full-screen-link" {{action (action this.attrs.exitFullScreen)}}>Edit Twiddle</a>
+      <a class="exit-full-screen-link" {{action (action this.exitFullScreen)}}>Edit Twiddle</a>
     {{/if}}
   </div>
 {{/twiddle-panes}}

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -39,11 +39,11 @@
                        isBuilding=isBuilding
                        buildErrors=buildErrors
       }}
-      <label class="checkbox-inline">
-        {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
-        Run Tests
-      </label>
     </div>
+    <label class="checkbox-inline twiddle-run-tests">
+      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
+      Run Tests
+    </label>
     {{run-or-live-reload liveReloadChanged=(action this.attrs.liveReloadChanged) runNow=(action this.attrs.runNow)}}
     <div class="url-bar">
       {{input value=applicationUrl enter=(route-action "urlChanged")}}

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -39,11 +39,11 @@
                        isBuilding=isBuilding
                        buildErrors=buildErrors
       }}
+      <label class="checkbox-inline">
+        {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
+        Run Tests
+      </label>
     </div>
-    <label class="checkbox-inline">
-      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
-      Run Tests
-    </label>
     {{run-or-live-reload liveReloadChanged=(action this.attrs.liveReloadChanged) runNow=(action this.attrs.runNow)}}
     <div class="url-bar">
       {{input value=applicationUrl enter=(route-action "urlChanged")}}

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -40,6 +40,10 @@
                        buildErrors=buildErrors
       }}
     </div>
+    <label class="checkbox-inline">
+      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.attrs.switchTests)}}
+      Run Tests
+    </label>
     {{run-or-live-reload liveReloadChanged=(action this.attrs.liveReloadChanged) runNow=(action this.attrs.runNow)}}
     <div class="url-bar">
       {{input value=applicationUrl enter=(route-action "urlChanged")}}

--- a/app/templates/components/main-gist.hbs
+++ b/app/templates/components/main-gist.hbs
@@ -28,6 +28,7 @@
             buildErrors=buildErrors
             applicationUrl=applicationUrl
             buildOutput=buildOutput
+            testsEnabled=testsEnabled
             openFile=(action "openFile")
             hideFileTree=(action "hideFileTree")
             focusEditor=(action "focusEditor")
@@ -39,4 +40,5 @@
             liveReloadChanged=(action "liveReloadChanged")
             runNow=(action "runNow")
             exitFullScreen=(action "exitFullScreen")
+            switchTests=(action "switchTests")
 }}


### PR DESCRIPTION
- disables app running alongside tests, now either the app runs or the tests
- added `legacy-testing` option which when enabled restores the previous behavior
- added "Run Tests" button, which switches the `enable-testing` property in `twiddle.json`
- when clicking "Run Tests" it ensures that test helper files are created
- made some small code cleanups (removed usage of `this.attrs` in the `gist-body` template, use spread syntax for calling super)

[Demo here](http://twiddlefork.herokuapp.com/34a8cd8babf1d7aa2c1a016188756d23?openFiles=tests.helpers.destroy-app.js%2C)