### PR TITLE
CSS fixes and improvements

### DIFF
--- a/app/components/twiddle-panes.js
+++ b/app/components/twiddle-panes.js
@@ -14,9 +14,9 @@ export default Ember.Component.extend({
   didRender() {
     this._super(...arguments);
     if (!this.get('media.isMobile')) {
-      this.$('.twiddle-pane').after('<div class="handle"></div>');
+      this.$('.twiddle-pane.code, .twiddle-pane.output').after('<div class="handle"></div>');
       this.$('.handle').last().remove();
-      this.$('.handle').drags({ pane: '.twiddle-pane' });
+      this.$('.handle').drags({ pane: '.twiddle-pane.code, .twiddle-pane.output' });
     }
   },
 

--- a/app/components/twiddle-panes.js
+++ b/app/components/twiddle-panes.js
@@ -12,10 +12,11 @@ export default Ember.Component.extend({
   },
 
   didRender() {
+    this._super(...arguments);
     if (!this.get('media.isMobile')) {
-      this.$('.col-md-4').after('<div class="handle"></div>');
+      this.$('.twiddle-pane').after('<div class="handle"></div>');
       this.$('.handle').last().remove();
-      this.$('.handle').drags({pane: ".col-md-4"});
+      this.$('.handle').drags({ pane: '.twiddle-pane' });
     }
   },
 

--- a/app/components/twiddle-panes.js
+++ b/app/components/twiddle-panes.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     if (!this.get('media.isMobile')) {
       this.$('.twiddle-pane').after('<div class="handle"></div>');
       this.$('.handle').last().remove();
-      this.$('.handle').drags({ pane: '.twiddle-pane' });
+      this.$('.handle').drags({ pane: '.twiddle-pane', min: 20 });
     }
   },
 

--- a/app/components/twiddle-panes.js
+++ b/app/components/twiddle-panes.js
@@ -14,9 +14,9 @@ export default Ember.Component.extend({
   didRender() {
     this._super(...arguments);
     if (!this.get('media.isMobile')) {
-      this.$('.twiddle-pane.code, .twiddle-pane.output').after('<div class="handle"></div>');
+      this.$('.twiddle-pane').after('<div class="handle"></div>');
       this.$('.handle').last().remove();
-      this.$('.handle').drags({ pane: '.twiddle-pane.code, .twiddle-pane.output' });
+      this.$('.handle').drags({ pane: '.twiddle-pane' });
     }
   },
 

--- a/app/styles/_output-pane.scss
+++ b/app/styles/_output-pane.scss
@@ -28,7 +28,7 @@
   background-color: transparent;
   position: relative;
   left: -2px;
-  z-index: 100;
+  z-index: 1000;
 
   @media (min-width: $screen-md-min) {
     height: 100%;

--- a/app/styles/_output-pane.scss
+++ b/app/styles/_output-pane.scss
@@ -18,11 +18,9 @@
 }
 
 .run-or-live-reload {
-  position: absolute;
-  right: 0;
-  top: 8px;
-  margin: 10px 25px;
   text-align: right;
+  margin-left: 10px;
+  font-size: 14px;
 }
 
 .handle {
@@ -37,9 +35,7 @@
 }
 
 .twiddle-run-tests {
-  position: absolute;
-  right: 106px;
-  top: 10px;
-  margin: 10px 25px;
+  margin-left: auto;
   text-align: right;
+  font-size: 14px;
 }

--- a/app/styles/_output-pane.scss
+++ b/app/styles/_output-pane.scss
@@ -28,6 +28,7 @@
   background-color: transparent;
   position: relative;
   left: -2px;
+  z-index: 100;
 
   @media (min-width: $screen-md-min) {
     height: 100%;

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -114,7 +114,7 @@
 
     @media (min-width: $screen-md-min) {
       position: absolute;
-      right: ($topbar-height - $topbar-control-height) / 2;
+      right: 0;
       top: ($topbar-height - $topbar-control-height) / 2;
     }
 
@@ -154,7 +154,7 @@
 
     @media (min-width: $screen-md-min) {
       position: absolute;
-      left: ($topbar-height - $topbar-control-height) / 2;
+      left: 0;
       top: ($topbar-height - $topbar-control-height) / 2;
     }
 
@@ -172,6 +172,7 @@
 
     @media (min-width: $screen-md-min) {
       position: absolute;
+      top: 6px;
       left: 50%;
       margin-left: -400px;
       width: 800px;

--- a/app/styles/_toolbar.scss
+++ b/app/styles/_toolbar.scss
@@ -167,10 +167,11 @@
     padding: 13px 0;
     text-align: center;
     display: inline-block;
+    margin-left: auto;
+    margin-right: auto;
 
     @media (min-width: $screen-md-min) {
       position: absolute;
-      top: 0;
       left: 50%;
       margin-left: -400px;
       width: 800px;
@@ -190,6 +191,7 @@
     }
 
     .indicator {
+      display: inline;
       text-transform: uppercase;
       font-weight: bold;
       color: #faf2ee;
@@ -204,8 +206,7 @@
     }
 
     .input-edit {
-      display: inline-block;
-      padding: 5px 10px;
+      display: inline;
       transition: background .3s;
       font-size: $font-size-larger;
       border-radius: 3px;

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -10,7 +10,6 @@
   @media (min-width: $screen-md-min) {
     display: -webkit-flex;
     display: flex;
-    align-content: stretch;
   }
 
   .twiddle-pane {
@@ -30,8 +29,8 @@
     flex: 1;
   }
 
-  .twiddle-pane.file-tree {
-    min-width: 180px;
+  .twiddle-pane.file-tree .jstree {
+    margin: 0 10px;
   }
 
   .handle + .twiddle-pane {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -14,8 +14,6 @@
   }
 
   .twiddle-pane {
-    -webkit-flex: 1;
-    flex: 1;
     padding: 0;
     height: 100%;
     border-right: 1px solid #e4e2e2;
@@ -24,6 +22,19 @@
 
     @media (max-width: $screen-md-min) {
       margin-bottom: 60px;
+    }
+  }
+
+  .twiddle-pane.code, .twiddle-pane.output {
+    -webkit-flex: 1;
+    flex: 1;
+  }
+
+  .twiddle-pane.file-tree {
+    min-width: 180px;
+
+    .js-tree {
+      padding: 0 10px;
     }
   }
 

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -10,22 +10,24 @@
   @media (min-width: $screen-md-min) {
     display: -webkit-flex;
     display: flex;
+    align-content: stretch;
   }
 
-  .col-md-4 {
-    -webkit-flex: 0.5;
-    flex: 0.5;
+  .twiddle-pane {
+    -webkit-flex: 1;
+    flex: 1;
     padding: 0;
     height: 100%;
     border-right: 1px solid #e4e2e2;
     cursor: normal;
+    position: relative;
 
     @media (max-width: $screen-md-min) {
       margin-bottom: 60px;
     }
   }
 
-  .handle + .col-md-4 {
+  .handle + .twiddle-pane {
     margin-left: -3px;
   }
 

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -31,9 +31,20 @@
   }
 
   .twiddle-pane.file-tree {
+    @media (min-width: $screen-md-min) {
+      max-width: 40%;
+    }
+
+    > .ember-view {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
 
     .jstree {
-      margin: 0 10px;
+      height: 100%;
+      overflow-x: auto;
+      padding: 0 10px;
     }
   }
 
@@ -74,6 +85,7 @@
     align-items: center;
     padding: 0 15px;
     height: $code-header-height;
+    min-height: $code-header-height;
     border-bottom: 1px solid $grey-3;
     font-size: 16px;
     background-color: $grey-1;

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -66,8 +66,8 @@
     font-size: 16px;
     background-color: $grey-1;
 
-    .nav-left+.file-picker {
-      margin-left: 30px;
+    span+.build-msgs {
+      margin-left: 10px;
     }
 
     .nav-right {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -163,3 +163,14 @@
     cursor: pointer;
   }
 }
+
+.gist-header {
+  position: relative;
+
+  > .visible-toolbar {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -31,7 +31,6 @@
   }
 
   .twiddle-pane.file-tree {
-    flex: 0 1 0%;
 
     .jstree {
       margin: 0 10px;

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -143,6 +143,18 @@
       padding-bottom: 3px;
       padding-left: 3px;
     }
+
+    .nav-pills {
+      max-width: 90%;
+
+      > li {
+        max-width: 100%;
+
+        > a {
+          overflow: hidden;
+        }
+      }
+    }
   }
 
   .full-screen {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -32,10 +32,6 @@
 
   .twiddle-pane.file-tree {
     min-width: 180px;
-
-    .jstree {
-      padding: 0 10px;
-    }
   }
 
   .handle + .twiddle-pane {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -34,7 +34,6 @@
     position: relative;
 
     span {
-      margin: 16px 25px;
       display: inline-block;
     }
 
@@ -59,33 +58,20 @@
   }
 
   .header {
+    display: flex;
+    align-items: center;
+    padding: 0 15px;
     height: $code-header-height;
     border-bottom: 1px solid $grey-3;
     font-size: 16px;
     background-color: $grey-1;
-    position: relative;
-
-    .nav-left {
-      position: absolute;
-      top: 18px;
-      left: 15px;
-    }
-
-    .file-picker {
-      margin-left: 15px;
-      margin-top: 8px;
-      margin-bottom: 0;
-      position: absolute;
-    }
 
     .nav-left+.file-picker {
       margin-left: 30px;
     }
 
     .nav-right {
-      position: absolute;
-      top: 20px;
-      right: 15px;
+      margin-left: auto;
     }
 
     .glyphicon {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -56,6 +56,10 @@
     border-right: none;
     position: relative;
 
+    .header {
+      padding-right: 28px;
+    }
+
     span {
       display: inline-block;
     }

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -15,6 +15,7 @@
   .twiddle-pane {
     padding: 0;
     height: 100%;
+    min-width: 200px;
     border-right: 1px solid #e4e2e2;
     cursor: normal;
     position: relative;

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -30,8 +30,12 @@
     flex: 1;
   }
 
-  .twiddle-pane.file-tree .jstree {
-    margin: 0 10px;
+  .twiddle-pane.file-tree {
+    flex: 0 1 0%;
+
+    .jstree {
+      margin: 0 10px;
+    }
   }
 
   .handle + .twiddle-pane {

--- a/app/styles/_twiddle-panes.scss
+++ b/app/styles/_twiddle-panes.scss
@@ -33,7 +33,7 @@
   .twiddle-pane.file-tree {
     min-width: 180px;
 
-    .js-tree {
+    .jstree {
       padding: 0 10px;
     }
   }

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -1,7 +1,7 @@
 {{#twiddle-panes numColumns=numColumns fullScreen=fullScreen fileTreeShown=fileTreeShown}}
   {{#unless fullScreen}}
     {{#if fileTreeShown}}
-      <div class="col-md-4 file-tree">
+      <div class="twiddle-pane file-tree">
         {{file-tree model=model
                     openFile=(action this.openFile)
                     hideFileTree=(action this.hideFileTree)
@@ -11,7 +11,7 @@
 
     {{#each columns as |column|}}
       {{#if column.show}}
-        <div class="col-md-4 code {{if column.active 'active' ''}}">
+        <div class="twiddle-pane code {{if column.active 'active' ''}}">
           {{file-editor-column col=column.col
                                file=column.file
                                allFiles=model.files
@@ -30,7 +30,7 @@
     {{/each}}
   {{/unless}}
 
-  <div class="col-md-4 output {{if fullScreen 'full-screen'}}">
+  <div class="twiddle-pane output {{if fullScreen 'full-screen'}}">
     <div class="header">
       {{#if noColumns}}
         <span class="glyphicon glyphicon-plus" {{action (action this.addColumn)}} title="Show an editor panel"></span>

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -39,12 +39,12 @@
                        isBuilding=isBuilding
                        buildErrors=buildErrors
       }}
+      <label class="checkbox-inline twiddle-run-tests">
+        {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.switchTests)}}
+        Run Tests
+      </label>
+      {{run-or-live-reload liveReloadChanged=(action this.liveReloadChanged) runNow=(action this.runNow)}}
     </div>
-    <label class="checkbox-inline twiddle-run-tests">
-      {{better-checkbox id="switch-tests" checked=testsEnabled action=(action this.switchTests)}}
-      Run Tests
-    </label>
-    {{run-or-live-reload liveReloadChanged=(action this.liveReloadChanged) runNow=(action this.runNow)}}
     <div class="url-bar">
       {{input value=applicationUrl enter=(route-action "urlChanged")}}
     </div>

--- a/app/templates/components/gist-body.hbs
+++ b/app/templates/components/gist-body.hbs
@@ -11,7 +11,7 @@
 
     {{#each columns as |column|}}
       {{#if column.show}}
-        <div class="twiddle-pane code {{if column.active 'active' ''}}">
+        <div class="twiddle-pane code {{if column.active 'active'}}">
           {{file-editor-column col=column.col
                                file=column.file
                                allFiles=model.files

--- a/app/templates/components/gist-header.hbs
+++ b/app/templates/components/gist-header.hbs
@@ -1,17 +1,15 @@
-<nav class="navbar-default">
-  <div class="row toolbar">
-    <div>
-      <div class="title">
-        {{title-input value=model.description titleChanged=(action this.attrs.titleChanged)}}
-        {{saved-state-indicator model=model unsaved=unsaved}}
-      </div>
-
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsed-menu" aria-expanded="false">
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
+<nav class="navbar-default gist-header">
+  <div class="row toolbar visible-toolbar">
+    <div class="title">
+      {{title-input value=model.description titleChanged=(action this.attrs.titleChanged)}}
+      {{saved-state-indicator model=model unsaved=unsaved}}
     </div>
+
+    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsed-menu" aria-expanded="false">
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
   </div>
 
   <div id="collapsed-menu" class="collapse navbar-collapse row toolbar">

--- a/tests/acceptance/columns-test.js
+++ b/tests/acceptance/columns-test.js
@@ -13,7 +13,7 @@ const plusGlyph = ".code .glyphicon-plus";
 const removeGlyph = firstColumn + " .glyphicon-remove";
 const outputPlusGlyph = ".output .glyphicon-plus";
 const showFileTreeGlyph = firstColumn + " .glyphicon-chevron-right";
-const hideFileTreeGlyph = ".col-md-4:first-of-type .glyphicon-chevron-left";
+const hideFileTreeGlyph = ".twiddle-pane:first-of-type .glyphicon-chevron-left";
 
 test('you can add and remove columns', function(assert) {
   visit('/');

--- a/tests/integration/components/twiddle-panes-test.js
+++ b/tests/integration/components/twiddle-panes-test.js
@@ -16,16 +16,16 @@ test('it renders', function(assert) {
 
   this.render(hbs`
     {{#twiddle-panes numColumns=numColumns}}
-      <div class="col-md-4"></div>
-      <div class="col-md-4"></div>
-      <div class="col-md-4"></div>
-      <div class="col-md-4"></div>
+      <div class="twiddle-pane"></div>
+      <div class="twiddle-pane"></div>
+      <div class="twiddle-pane"></div>
+      <div class="twiddle-pane"></div>
     {{/twiddle-panes}}
   `);
 
   assert.equal(this.$('.handle').length, 3, 'Renders 3 handles if 4 columns');
 
-  this.$('.col-md-4').last().after('<div class="col-md-4"></div>');
+  this.$('.twiddle-pane').last().after('<div class="twiddle-pane"></div>');
   this.set('numColumns', 5);
 
   assert.equal(this.$('.handle').length, 4, 'Increases handles to 4 if a column is inserted');

--- a/vendor/drags.js
+++ b/vendor/drags.js
@@ -7,7 +7,7 @@
       return;
     }
 
-    opt = $.extend({handle:"",pane:"",cursor:"col-resize", min: 25}, opt);
+    opt = $.extend({ handle:"",pane:"",cursor:"col-resize", min: 25, minWidth: 200 }, opt);
 
     var $el;
     if(opt.handle === "") {
@@ -55,7 +55,7 @@
       var leftPercentage = (((e.pageX - prev.offset().left) + (pos_x - drg_w / 2)) / total);
       var rightPercentage = 1 - leftPercentage;
 
-      if(leftPercentage * 100 < opt.min || rightPercentage * 100 < opt.min)
+      if(leftWidth <= opt.minWidth || leftPercentage * 100 < opt.min || rightPercentage * 100 < opt.min)
       {
         return;
       }

--- a/vendor/drags.js
+++ b/vendor/drags.js
@@ -50,9 +50,15 @@
       // the next X for prev
 
       var total = prev.outerWidth() + next.outerWidth();
-      var totalFlex = parseFloat(prev.css('flex-grow')) + parseFloat(next.css('flex-grow'));
+      var leftFlexGrow = parseFloat(prev.css('flex-grow'));
 
-      var leftPercentage = (((e.pageX - prev.offset().left) + (pos_x - drg_w / 2)) / total);
+      if (leftFlexGrow === 0) {
+        leftFlexGrow = prev.outerWidth() / next.outerWidth();
+      }
+
+      var totalFlex =  leftFlexGrow + parseFloat(next.css('flex-grow'));
+      var leftWidth = (e.pageX - prev.offset().left) + (pos_x - drg_w / 2);
+      var leftPercentage = leftWidth / total;
       var rightPercentage = 1 - leftPercentage;
 
       if(leftWidth <= opt.minWidth || leftPercentage * 100 < opt.min || rightPercentage * 100 < opt.min)


### PR DESCRIPTION
The main issue I was trying to fix is that the "Run Tests" and "Live Reload" checkboxes cover each other when "Live Reload" is deselected:
Before:
![image](https://cloud.githubusercontent.com/assets/1474323/18526091/747cca54-7abf-11e6-9d04-37fe2298c5c5.png)
After:
![image](https://cloud.githubusercontent.com/assets/1474323/18526102/81954e96-7abf-11e6-8c8e-a18d0a9a47d3.png)

Other problems this will fix (discovered while fixing the first issue):
- the header elements are consistently positioned (especially vertically) across all panes (esp. visible for eg. the on "Output" string):
Before:
![image](https://cloud.githubusercontent.com/assets/1474323/18526136/aab4c680-7abf-11e6-8aff-ecd6f3868cbe.png)
After:
![image](https://cloud.githubusercontent.com/assets/1474323/18526203/f17ea6a8-7abf-11e6-9765-ac0a2d5181fb.png)

- [when the tree is hidden and there are 0 editor panes](https://ember-twiddle.com/?fileTreeShown=false&numColumns=0) the page looked broken:
Before:
![image](https://cloud.githubusercontent.com/assets/1474323/18527664/f7bac0f0-7ac5-11e6-84f2-67734beb1801.png)
After:
![image](https://cloud.githubusercontent.com/assets/1474323/18527675/0148f948-7ac6-11e6-820a-e9e1cbea76ee.png)

- I've changed how the file tree looks and behaves, it is no longer resizable and is much smaller which leaves more space for the important stuff (it still expands when the tree shifts to the right due to many items):
Before:
![image](https://cloud.githubusercontent.com/assets/1474323/18528165/2095c8ba-7ac8-11e6-87e3-b3cdc024e208.png)
After:
![image](https://cloud.githubusercontent.com/assets/1474323/18528145/0938930a-7ac8-11e6-931b-13944c98d9f5.png)

Mobile view (only last screen has real changes so I provide a "before" screenshot there):
![image](https://cloud.githubusercontent.com/assets/1474323/18529159/4755c96a-7acc-11e6-817f-86650b59fa4c.png)
![image](https://cloud.githubusercontent.com/assets/1474323/18529163/4c80f50e-7acc-11e6-8839-8b24336bff97.png)

Fixed output pane:
Before:
![image](https://cloud.githubusercontent.com/assets/1474323/18529209/77d6aac8-7acc-11e6-848b-9f4c2fa92eab.png)
After:
![image](https://cloud.githubusercontent.com/assets/1474323/18529195/699812b2-7acc-11e6-93a2-a1f530c3a848.png)




Edit: I think I'd add a little more spacing to the file tree (left/right) looks a bit too cramped together imo