### PR TITLE
Added underlines to saved twiddle links

### DIFF
--- a/app/styles/_saved-twiddles.scss
+++ b/app/styles/_saved-twiddles.scss
@@ -14,4 +14,8 @@ div.table-responsive {
   tbody tr:hover {
     background-color: $pale-orange;
   }
+  
+  a {
+    text-decoration: underline;
+  }
 }

--- a/app/styles/_saved-twiddles.scss
+++ b/app/styles/_saved-twiddles.scss
@@ -13,9 +13,17 @@ div.table-responsive {
 
   tbody tr:hover {
     background-color: $pale-orange;
+    
+    a {
+      color: white;
+    }
   }
   
   a {
     text-decoration: underline;
+    color: $pale-orange;
+  }
+  a:hover {
+    text-decoration: none;
   }
 }


### PR DESCRIPTION
I was expecting to be able to click the SHA and not having any luck.  I had no idea the Twiddle column and Gist column names were actually links I could click.  This makes it a little easier to see where the links are on the page:

![screen shot 2016-11-19 at 7 28 08 pm](https://cloud.githubusercontent.com/assets/802505/20459855/565889d4-ae8e-11e6-9ac8-f7c63d135348.png)
