### PR TITLE
Upgrade ember-cli-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-moment-shim": "~2.2.1",
     "ember-cli-qunit": "~2.1.0",
     "ember-cli-release": "1.0.0-beta.2",
-    "ember-cli-sass": "~5.6.0",
+    "ember-cli-sass": "~6.0.0",
     "ember-cli-sri": "~2.1.0",
     "ember-cli-test-loader": "~1.1.0",
     "ember-cli-uglify": "~1.2.0",


### PR DESCRIPTION
One step closer to dealing with #483

`ember-cli-sass` includes `node-sass` 4.1.0, which has support for alpine linux