### PR TITLE
adding github enterprise support

### DIFF
--- a/app/routes/gist.js
+++ b/app/routes/gist.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
+import config from '../config/environment';
 
 const { inject, $ } = Ember;
 
 const CONFIRM_MSG = "Unsaved changes will be lost.";
 
 export default Ember.Route.extend({
+  toriiProvider: config.toriiProvider,
   notify: inject.service('notify'),
   app: inject.service(),
   fastboot: inject.service(),
@@ -12,7 +14,7 @@ export default Ember.Route.extend({
   titleToken: Ember.computed.readOnly('controller.model.description'),
 
   beforeModel () {
-    return this.session.fetch('github-oauth2').catch(function() {
+    return this.session.fetch(this.get('toriiProvider')).catch(function() {
       // Swallow error for now
     });
   },
@@ -98,7 +100,7 @@ export default Ember.Route.extend({
     },
 
     signInViaGithub () {
-      this.session.open('github-oauth2').catch(function(error) {
+      this.session.open(this.get('toriiProvider')).catch(function(error) {
         if (alert) {
           alert('Could not sign you in: ' + error.message);
         }

--- a/app/routes/twiddles.js
+++ b/app/routes/twiddles.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
+import config from '../config/environment';
 
 export default Ember.Route.extend({
   titleToken: 'My Saved Twiddles',
-
+  torriProvider: config.torriProvider,
   beforeModel() {
-    return this.session.fetch('github-oauth2').catch(error => {
+    return this.session.fetch(this.get('torriProvider')).catch(error => {
       if (!error) {
         this.transitionTo('/');
       }

--- a/app/torii-providers/github-enterprise.js
+++ b/app/torii-providers/github-enterprise.js
@@ -1,0 +1,27 @@
+import Oauth2 from 'torii/providers/oauth2-code';
+import {configurable} from 'torii/configuration';
+
+/**
+* This class implements authentication against Github Enterprise
+* using the OAuth2 authorization flow in a popup window.
+* It is based on the github-oauth2 provider in the torii project
+* @class
+*/
+var GithubEnterprse = Oauth2.extend({
+  name: 'github-enterprise',
+  baseUrl: configurable('baseUrl', function(){
+    // A hack that allows redirectUri to be configurable
+    // but default to the superclass
+    return this._super();
+  }),
+
+  responseParams: ['code', 'state'],
+
+  redirectUri: configurable('redirectUri', function(){
+    // A hack that allows redirectUri to be configurable
+    // but default to the superclass
+    return this._super();
+  })
+});
+
+export default GithubEnterprse;

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,15 +1,23 @@
 /* jshint node: true */
 
 module.exports = function(environment) {
+  var rootURL = process.env.TWIDDLE_ROOT_URL || '/ember-twiddle';
+  var host = process.env.GH_API_HOST || 'https://api.github.com';
+  var torriGHEBaseURL = process.env.TORII_GHE_OAUTH || null;
+  var torriProvider = process.env.TORII_PROVIDER || 'github-oauth2';
+  var githubOauthURL = process.env.GATEKEEPER_URL || 'http://localhost:9999/authenticate/';
+  var assetHost = process.env.TWIDDLE_ASSET_HOST || '/ember-twiddle/';
+  var githubApiKey = process.env.GH_API_KEY || '2b84ab967ef8266ca0dc'
+
   var ENV = {
     modulePrefix: 'ember-twiddle',
     environment: environment,
-    rootURL: '/',
+    rootURL: rootURL,
     locationType: 'auto',
-    host: 'https://api.github.com',
-    githubOauthUrl: 'http://localhost:9999/authenticate/',
+    host: host,
+    githubOauthUrl: githubOauthURL,
     addonUrl: 'https://emw2ujz4u1.execute-api.us-east-1.amazonaws.com/canary/addon',
-    assetsHost: '/',
+    assetsHost: assetHost,
     maxNumFilesInitiallyExpanded: 12,
     EmberENV: {
       FEATURES: {
@@ -18,21 +26,12 @@ module.exports = function(environment) {
       }
     },
 
+
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
       rootElement: '#main-app'
     },
-
-    torii: {
-      sessionServiceName: 'session',
-      providers: {
-        'github-oauth2': {
-          scope: 'gist',
-          apiKey: '2b84ab967ef8266ca0dc'
-        }
-      }
-    }
 
   };
 
@@ -42,6 +41,8 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.rootURL = '/',
+    ENV.assetsHost = '/',
 
     ENV['ember-cli-mirage'] = {
       enabled: false
@@ -61,20 +62,24 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.githubOauthUrl = 'https://ember-twiddle.herokuapp.com/authenticate/';
-    ENV.assetsHost = '//assets.ember-twiddle.com/';
+    ENV.githubOauthUrl = githubOauthURL;
+    ENV.assetsHost = assetHost;
     ENV.torii = {
       sessionServiceName: 'session',
-      providers: {
-        'github-oauth2': {
-          scope: 'gist',
-          apiKey: '3df37009938c0790d952'
-        }
-      }
-    };
+      providers: {},
+    },
+    ENV.torii.proviers[torriProvider] = {
+        scope: 'gist',
+            apiKey: githubApiKey
+    }
+    // we only need to set the baseUrl if we are using GH Enterprise
+    if( torriGHEBaseURL ) {
+      ENV.torii.proviers[torriProvider].baseUrl = torriGHEBaseURL;
+    }
     ENV.addonUrl = "https://howq105a2c.execute-api.us-east-1.amazonaws.com/production/addon";
   }
 
+  // staging to GH Enterprise is not currently supported.
   if (environment === 'staging') {
     ENV.githubOauthUrl = 'https://canary-twiddle-gatekeeper.herokuapp.com/authenticate/';
     ENV.assetsHost = '//canary-assets.ember-twiddle.com/';


### PR DESCRIPTION
This PR is to add github enterprise support so that ember-twiddle can be run privately if required.

Basically, this PR just replaces hard coded strings with reading from environmental variables.   I new torii provider for github enterprise was added because the baseUrl and redirectUrl are different for github enterprise distributions.

I talked to @Gaurav0 about this months ago.  Takes me a while to get PRs up due to company policy.