### PR TITLE
Fix help link

### DIFF
--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -17,13 +17,14 @@ export default Ember.Component.extend({
     return this.get('version').charAt(0) === "v" ? "" : "v";
   }),
 
-  currentVersionLink: computed('environment', 'version', 'currentRevision', function() {
+  currentVersionLink: computed('environment', 'v', 'version', 'currentRevision', function() {
     var baseLink = "https://github.com/ember-cli/ember-twiddle";
-    var { environment, currentRevision, version } = this.getProperties('environment', 'currentRevision', 'version');
+    var { environment, currentRevision, v, version } = this.getProperties('environment', 'currentRevision', 'v', 'version');
+    var tagName = `${v}${version}`;
 
     switch (environment) {
       case 'production':
-        return `${baseLink}/releases/tag/${version}`;
+        return `${baseLink}/releases/tag/${tagName}`;
 
       case 'staging':
         return `${baseLink}/commit/${currentRevision}`;

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -65,7 +65,7 @@ test('shows link to release when in production environment', function(assert) {
   this.render(hbs`{{user-menu environment="production" version="4.0.4" }}`);
 
   assert.equal(this.$('.test-current-version-link').length, 1);
-  assert.equal(this.$('.test-current-version-link').attr('href'), "https://github.com/ember-cli/ember-twiddle/releases/tag/4.0.4");
+  assert.equal(this.$('.test-current-version-link').attr('href'), "https://github.com/ember-cli/ember-twiddle/releases/tag/v4.0.4");
   assert.equal(this.$('.test-current-version-link').text().trim(), "Ember Twiddle v4.0.4");
 });
 


### PR DESCRIPTION
Currently the first item in the help menu on the top right of the site links to https://github.com/ember-cli/ember-twiddle/releases/tag/0.11.0 (404) instead of https://github.com/ember-cli/ember-twiddle/releases/tag/v0.11.0. I think this PR will fix it but haven't tested.