### PR TITLE
Enabling default keymap, and setting as default

### DIFF
--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -10,7 +10,7 @@ export default ObjectProxy.extend({
   storageKey: 'ember_twiddle_settings',
 
   defaultSettings: {
-    keyMap: 'basic'
+    keyMap: 'default'
   },
 
   init() {

--- a/app/templates/components/editor-mode-menu.hbs
+++ b/app/templates/components/editor-mode-menu.hbs
@@ -3,6 +3,7 @@
 </a>
 
 <ul class="dropdown-menu dropdown-menu-right">
+  <li><a {{action 'setKeyMap' 'default'}} class="key-map-option default">Default</a></li>
   <li><a {{action 'setKeyMap' 'basic'}} class="key-map-option basic">Basic</a></li>
   <li><a {{action 'setKeyMap' 'vim'}} class="key-map-option vim">Vim</a></li>
   <li><a {{action 'setKeyMap' 'emacs'}} class="key-map-option emacs">Emacs</a></li>

--- a/tests/unit/models/settings-test.js
+++ b/tests/unit/models/settings-test.js
@@ -23,7 +23,7 @@ test('it has default settings when no local settings are present', function(asse
   const settings = this.subject();
 
   assert.deepEqual(getProperties(settings, 'keyMap'), {
-    keyMap: 'basic'
+    keyMap: 'default'
   }, 'default settings are present');
 });
 


### PR DESCRIPTION
I would like to hit `ctrl-arrow` when editing ember twiddles and have it work. :smiley: 

From the docs: http://codemirror.net/doc/manual.html
> keyMap: string
Configures the key map to use. The default is "default", which is the only key map defined in codemirror.js itself. Extra key maps are found in the key map directory. See the section on key maps for more information.

https://github.com/codemirror/CodeMirror/blob/master/src/input/keymap.js