### PR TITLE
Dropdown menu should be higher than handle

### DIFF
--- a/app/styles/_output-pane.scss
+++ b/app/styles/_output-pane.scss
@@ -28,7 +28,7 @@
   background-color: transparent;
   position: relative;
   left: -2px;
-  z-index: 1000;
+  z-index: 999;
 
   @media (min-width: $screen-md-min) {
     height: 100%;


### PR DESCRIPTION
If the dropdown menu is open over the pane resize handle, the menu will unexpectedly close when the mouse reaches the handle.

This fix bumps the z-index back down (a change was made that increased the `z-index` of `.handle`) below that of  `.dropdown-menu`.

#### Example Behaviour
![example_twiddle](https://cloud.githubusercontent.com/assets/6111995/23288814/b449913e-fa13-11e6-961d-70030e516b73.gif)
