### PR TITLE
Import `jQuery` instead of using `$`.

### DIFF
--- a/blueprints/mouse_events_initializer.js
+++ b/blueprints/mouse_events_initializer.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
+import jQuery from 'jquery';
 import config from '../config/environment';
 
 export default {
   name: 'mouse-events',
   initialize: function() {
-    $(window).on("mousemove", function(event) {
+    jQuery(window).on("mousemove", function(event) {
       window.parent.postMessage({
         mousemove: {
           pageX: event.pageX,
@@ -12,7 +13,7 @@ export default {
         }
       }, config.TWIDDLE_ORIGIN);
     });
-    $(window).on("mouseup", function(event) {
+    jQuery(window).on("mouseup", function(event) {
       window.parent.postMessage({
         mouseup: {
           pageX: event.pageX,


### PR DESCRIPTION
There are scenarios where `$` is rebound (e.g. when using [prototype.js](http://prototypejs.org/)).

We should use `jQuery` instead of `$` (it also makes it somewhat more clear what we are doing IMO).