### PR TITLE
removed redundant `RSVP.resolve`s

### DIFF
--- a/app/mixins/gist-controller.js
+++ b/app/mixins/gist-controller.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 
-const { inject, RSVP, run } = Ember;
+const { inject, run } = Ember;
 
 export default Ember.Mixin.create({
   fastboot: inject.service(),
@@ -23,9 +23,8 @@ export default Ember.Mixin.create({
 
   actions: {
     transitionQueryParams(queryParams) {
-      return this.transitionToRoute({ queryParams: queryParams }).then(() => {
-        return RSVP.resolve(queryParams);
-      });
+      return this.transitionToRoute({ queryParams: queryParams })
+        .then(() => queryParams);
     }
   },
 

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -55,9 +55,7 @@ export default Ember.Service.extend({
 
   resolveAddons(addons, dependencies, emberVersion) {
     const taskInstance = this.get('resolveAddonsTask').perform(addons, dependencies, emberVersion);
-    return taskInstance.then(() => {
-      return RSVP.resolve(taskInstance.value);
-    });
+    return taskInstance.then(() => taskInstance.value);
   },
 
   resolveAddonsTask: task(function *(addons, dependencies, emberVersion) {
@@ -117,9 +115,9 @@ export default Ember.Service.extend({
   }),
 
   resolveAddon(name, value, emberVersion) {
+    const url = `${config.addonUrl}?ember_version=${emberVersion}&addon=${name}&addon_version=${value}`;
     return new RSVP.Promise(function(resolve) {
-      const url = `${config.addonUrl}?ember_version=${emberVersion}&addon=${name}&addon_version=${value}`;
-      resolve(Ember.$.getJSON(url).then(data => RSVP.resolve(data)));
+      Ember.$.getJSON(url).then(resolve);
     });
   },
 

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -228,8 +228,7 @@ export default Ember.Service.extend({
             legacyTesting: legacyTesting(twiddleJSON)
           }
         );
-
-        return RSVP.resolve(this.buildHtml(gist, out.join('\n'), cssOut.join('\n'), twiddleJSON));
+        return this.buildHtml(gist, out.join('\n'), cssOut.join('\n'), twiddleJSON);
       });
   },
 

--- a/app/services/twiddle-json.js
+++ b/app/services/twiddle-json.js
@@ -63,14 +63,11 @@ export default Ember.Service.extend({
       const emberVersion = twiddleJson.dependencies.ember;
       dependencyResolver.resolveDependencies(twiddleJson.dependencies);
       if ('addons' in twiddleJson) {
-        return dependencyResolver.resolveAddons(twiddleJson.addons, twiddleJson.dependencies, emberVersion).then(() => {
-          return RSVP.resolve(twiddleJson);
-        }).catch(() => {
-          return RSVP.reject();
-        });
+        return dependencyResolver.resolveAddons(twiddleJson.addons, twiddleJson.dependencies, emberVersion)
+          .then(() => twiddleJson);
       }
 
-      return RSVP.resolve(twiddleJson);
+      return twiddleJson;
     });
   },
 


### PR DESCRIPTION
when value returned inside `then` callback there is no need to wrap it with `RSVP.resolve`  it is always resolved unless wrapped in `RSVP.reject`