### PR TITLE
Use single quotes for model blueprints

### DIFF
--- a/blueprints/model.js
+++ b/blueprints/model.js
@@ -1,6 +1,6 @@
-import Model from "ember-data/model";
-import attr from "ember-data/attr";
-import { belongsTo, hasMany } from "ember-data/relationships";
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { belongsTo, hasMany } from 'ember-data/relationships';
 
 export default Model.extend({
 });


### PR DESCRIPTION
The other blueprints all use single quotes styled strings. The model is the only one that differs. This change makes the quote style consistent.