### PR TITLE
Fix #557: Adds extra menu item for renaming a file

### DIFF
--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -49,7 +49,7 @@
     </li>
     {{#if activeEditorCol}}
       <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Rename {{activeFile.filePath}}</a></li>
-      <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
+      <li><a {{action 'renameFile' activeFile}} class="test-move-action">Move {{activeFile.filePath}}</a></li>
       <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
     {{/if}}
     {{#if session.isAuthenticated}}

--- a/app/templates/components/file-menu.hbs
+++ b/app/templates/components/file-menu.hbs
@@ -48,6 +48,7 @@
       </ul>
     </li>
     {{#if activeEditorCol}}
+      <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Rename {{activeFile.filePath}}</a></li>
       <li><a {{action 'renameFile' activeFile}} class="test-rename-action">Move {{activeFile.filePath}}</a></li>
       <li><a {{action 'removeFile' activeFile}} class="test-remove-action">Delete {{activeFile.filePath}}</a></li>
     {{/if}}

--- a/tests/integration/components/file-menu-test.js
+++ b/tests/integration/components/file-menu-test.js
@@ -94,6 +94,15 @@ test("it calls renameFile on clicking 'Rename'", function(assert) {
   assert.equal(this.renamedFile, this.file, 'renameFile was called with file to rename');
 });
 
+test("it calls renameFile on clicking 'Move'", function(assert) {
+  assert.expect(2);
+
+  this.$('.test-move-action').click();
+
+  assert.ok(this.renameFileCalled, 'renameFile was called');
+  assert.equal(this.renamedFile, this.file, 'renameFile was called with file to rename');
+});
+
 test("it calls removeFile on clicking 'Remove'", function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
I've deicded to solve this issue by adding an extra menu item instead of writing something like "Move / Rename {{filename}}" or "Move or rename {{filename}} since I think it creates a lot of clutter. This won't help users figure out how to rename. 

Instead rename and move are seperate items of the menu with the same functionality. In my oppinion this provides a better user experience and more clearity. 