### PR TITLE
Support Ember 3.0 - 3.2

### DIFF
--- a/app/components/build-messages.js
+++ b/app/components/build-messages.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
         // eslint-disable-next-line no-console
         console.error(error);
       });
-      this.get('notify').info('Errors were dumped to console');
+      this.get('notify').error('Errors were dumped to console');
     }
   }
 });

--- a/app/services/dependency-resolver.js
+++ b/app/services/dependency-resolver.js
@@ -6,8 +6,8 @@ import compareVersions from 'compare-versions';
 
 const { computed, deprecate, inject, RSVP, testing } = Ember;
 
-const EMBER_VERSIONS = ['2.18.2', '2.17.2', '2.16.2', '2.15.3', '2.14.1', '2.13.0', '2.12.0'];
-const EMBER_DATA_VERSIONS = ['2.18.2', '2.17.1', '2.16.4', '2.15.3', '2.14.10', '2.13.2', '2.12.2'];
+const EMBER_VERSIONS = ['3.2.0', '3.1.2', '3.0.0', '2.18.2', '2.17.2', '2.16.2', '2.15.3', '2.14.1', '2.13.0', '2.12.0'];
+const EMBER_DATA_VERSIONS = ['3.1.1', '3.0.2', '2.18.2', '2.17.1', '2.16.4', '2.15.3', '2.14.10', '2.13.2', '2.12.2'];
 
 const VERSION_REGEX = /^\d+.\d+.\d+(-beta\.\d+)?$/;
 
@@ -165,7 +165,7 @@ export default Ember.Service.extend({
 
     if (name === 'ember-data') {
       const msg = 'It is recommended you use ember-data as an addon';
-      deprecate(msg, false, {
+      deprecate(msg, testing, {
         id: 'ember-twiddle.deprecate-ember-data-as-dependency',
         until: '0.16.0',
       });
@@ -176,7 +176,7 @@ export default Ember.Service.extend({
 
     if (compareVersions(version, '2.12.0') === -1) {
       const msg = 'Versions of Ember prior to 2.12.0 are no longer supported in Ember Twiddle';
-      deprecate(msg, false, {
+      deprecate(msg, testing, {
         id: 'ember-twiddle.deprecate-ember-versions-before-2-12',
         until: '0.16.0',
       });

--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js",
-    "ember": "2.18.2",
-    "ember-template-compiler": "2.18.2",
-    "ember-testing": "2.18.2"
+    "ember": "3.2.0",
+    "ember-template-compiler": "3.2.0",
+    "ember-testing": "3.2.0"
   },
   "addons": {
-    "ember-data": "2.18.2"
+    "ember-data": "3.1.1"
   }
 }

--- a/blueprints/twiddle.json
+++ b/blueprints/twiddle.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.14.1",
+  "version": "0.15.0",
   "EmberENV": {
     "FEATURES": {}
   },

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-twiddle",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "dependencies": {
     "jquery": "1.11.3",
     "bootstrap-sass": "~3.3.5",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -101,6 +101,8 @@ module.exports = function(defaults) {
   }
   app.import('vendor/bootstrap-dropdown-submenu-fix.css');
   app.import('vendor/hint.css');
+  app.import('node_modules/compare-versions/index.js');
+  app.import('vendor/shims/compare-versions.js');
 
   const nodeBuiltins = require('rollup-plugin-node-builtins');
   const json = require('rollup-plugin-json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-twiddle",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "https://ember-twiddle.com",
   "private": true,
   "directories": {
@@ -26,6 +26,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",
     "browserify": "^16.2.0",
+    "compare-versions": "^3.2.1",
     "dedent": "~0.7.0",
     "ember-ajax": "^3.0.0",
     "ember-api-actions": "~0.1.8",

--- a/tests/acceptance/dependency-test.js
+++ b/tests/acceptance/dependency-test.js
@@ -3,6 +3,26 @@ import moduleForAcceptance from 'ember-twiddle/tests/helpers/module-for-acceptan
 
 moduleForAcceptance('Acceptance | dependencies');
 
+const oldVersionContent = `
+{
+"dependencies": {
+"jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
+"ember": "1.13.10",
+"ember-data": "1.13.15"
+}
+}
+`;
+
+const newVersionContent = `
+{
+"dependencies": {
+"jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
+"ember": "2.17.0",
+"ember-data": "2.18.0"
+}
+}
+`;
+
 const TWIDDLE_SHOWING_VERSIONS = [
   {
     filename: "application.template.hbs",
@@ -24,16 +44,7 @@ const TWIDDLE_SHOWING_VERSIONS = [
     `
   },
   {
-    filename: 'twiddle.json',
-    content: `
-    {
-    "dependencies": {
-    "jquery": "https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js",
-    "ember": "1.13.10",
-    "ember-data": "1.13.15"
-    }
-    }
-    `
+    filename: 'twiddle.json'
   }
 ];
 
@@ -73,7 +84,18 @@ test('Able to run a gist using an external dependency', function(assert) {
   });
 });
 
-test('Able to resolve ember / ember-data dependencies via version only', function(assert) {
+test('Able to resolve ember / ember-data dependencies via version only (new versions)', function(assert) {
+  TWIDDLE_SHOWING_VERSIONS[2].content = newVersionContent;
+  runGist(TWIDDLE_SHOWING_VERSIONS);
+
+  andThen(function() {
+    assert.equal(outputContents('.ember-version'), '2.17.0');
+    assert.equal(outputContents('.ember-data-version'), '2.18.0');
+  });
+});
+
+test('Able to resolve ember / ember-data dependencies via version only (old versions)', function(assert) {
+  TWIDDLE_SHOWING_VERSIONS[2].content = oldVersionContent;
   runGist(TWIDDLE_SHOWING_VERSIONS);
 
   andThen(function() {
@@ -83,25 +105,26 @@ test('Able to resolve ember / ember-data dependencies via version only', functio
 });
 
 test('Dependencies can be changed via the UI', function(assert) {
+  TWIDDLE_SHOWING_VERSIONS[2].content = newVersionContent;
   runGist(TWIDDLE_SHOWING_VERSIONS);
 
   andThen(function() {
-    assert.equal(outputContents('.ember-version'), '1.13.10');
-    assert.equal(outputContents('.ember-data-version'), '1.13.15');
+    assert.equal(outputContents('.ember-version'), '2.17.0');
+    assert.equal(outputContents('.ember-data-version'), '2.18.0');
   });
 
   andThen(function() {
     click('.versions-menu .dropdown-toggle');
-    click('.test-set-ember-data-version:contains("2.1.0")');
+    click('.test-set-ember-data-version:contains("2.16.4")');
 
     click('.versions-menu .dropdown-toggle');
-    click('.test-set-ember-version:contains("2.1.2")');
+    click('.test-set-ember-version:contains("2.15.3")');
 
     waitForLoadedIFrame();
   });
 
   andThen(function() {
-    assert.equal(outputContents('.ember-version'), '2.1.2');
-    assert.equal(outputContents('.ember-data-version'), '2.1.0');
+    assert.equal(outputContents('.ember-version'), '2.15.3');
+    assert.equal(outputContents('.ember-data-version'), '2.16.4');
   });
 });

--- a/tests/acceptance/gist-test.js
+++ b/tests/acceptance/gist-test.js
@@ -321,6 +321,7 @@ test('unsaved indicator', function(assert) {
   click(firstColumnTextarea);
   fillIn(firstColumnTextarea, "\"some text\";");
   triggerEvent(firstColumnTextarea, "blur");
+  triggerEvent(firstColumnTextarea, "focusout");
 
   andThen(function() {
     return timeout(10);
@@ -362,6 +363,11 @@ test('editing a file updates gist', function(assert) {
   click(firstColumnTextarea);
   fillIn(firstColumnTextarea, '<div class="index">some text</div>');
   triggerEvent(firstColumnTextarea, "blur");
+  triggerEvent(firstColumnTextarea, "focusout");
+
+  andThen(function() {
+    return timeout(10);
+  });
 
   andThen(function() {
     assert.equal(find(firstColumnTextarea).val(), '<div class="index">some text</div>');

--- a/tests/integration/components/build-messages-test.js
+++ b/tests/integration/components/build-messages-test.js
@@ -19,7 +19,8 @@ test('it shows the number of build messages', function(assert) {
   this.set('buildErrors', []);
   this.set('isBuilding', false);
   this.set('notify', {
-    info() {}
+    info() {},
+    error() {}
   });
 
   this.render(hbs`{{build-messages buildErrors=buildErrors isBuilding=isBuilding notify=notify}}`);
@@ -31,12 +32,13 @@ test('it shows the number of build messages', function(assert) {
   assert.equal(this.$('span').text().replace(/\s+/g, " ").trim(), 'Output ( 2 build errors )', 'shows number of build errors');
 });
 
-test('it calls notify.info() when clicking on build errors', function(assert) {
+test('it calls notify.errpr() when clicking on build errors', function(assert) {
   assert.expect(1);
 
   let notifyObject = Ember.Object.create({
     called: false,
-    info() {
+    info() {},
+    error() {
       this.set('called', true);
     }
   });
@@ -50,5 +52,5 @@ test('it calls notify.info() when clicking on build errors', function(assert) {
 
   this.$('span a').click();
 
-  assert.ok(notifyObject.get('called'), "notify.info() was called");
+  assert.ok(notifyObject.get('called'), "notify.error() was called");
 });

--- a/vendor/shims/compare-versions.js
+++ b/vendor/shims/compare-versions.js
@@ -1,0 +1,12 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return {
+      'default': self['compareVersions'],
+      __esModule: true,
+    };
+  }
+
+  define('compare-versions', [], vendorModule);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,6 +2292,10 @@ commoner@~0.10.3:
     q "^1.1.2"
     recast "^0.11.17"
 
+compare-versions@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.1.tgz#a49eb7689d4caaf0b6db5220173fd279614000f7"
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"


### PR DESCRIPTION
Also deprecates:

1. Bringing in ember-data as a dependency rather than an addon
2. Ember versions prior to 2.12

Fixes #609 