### PR TITLE
Adds shortcut option to comment javascript code.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,8 @@ module.exports = {
     visit: true,
     waitForLoadedIFrame: true,
     waitForUnloadedIFrame: true,
-    '$': true
+    '$': true,
+    CodeMirror: false
   },
   rules: {
     'ember/new-module-imports': 'off'

--- a/app/app.js
+++ b/app/app.js
@@ -3,6 +3,12 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
+// adds "toggleCommentIndented" command to codemirror for default keymap
+
+if (CodeMirror) {
+  CodeMirror.keyMap.default['Cmd-/'] = 'toggleCommentIndented';
+}
+
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/app/app.js
+++ b/app/app.js
@@ -3,12 +3,6 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-// adds "toggleCommentIndented" command to codemirror for default keymap
-
-if (CodeMirror) {
-  CodeMirror.keyMap.default['Cmd-/'] = 'toggleCommentIndented';
-}
-
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/app/initializers/app-initializer.js
+++ b/app/initializers/app-initializer.js
@@ -1,0 +1,11 @@
+export function initialize(/* application */) {
+  // adds "toggleCommentIndented" command to codemirror for default keymap
+
+  if (CodeMirror) {
+    CodeMirror.keyMap.default['Cmd-/'] = 'toggleCommentIndented';
+  }
+}
+
+export default {
+  initialize
+};

--- a/app/templates/components/editor-mode-menu.hbs
+++ b/app/templates/components/editor-mode-menu.hbs
@@ -1,5 +1,5 @@
 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-  Keystroke Mode <b class="caret"></b>
+  Keystroke - {{selectedKeyMap}} <b class="caret"></b>
 </a>
 
 <ul class="dropdown-menu dropdown-menu-right">

--- a/app/templates/components/gist-header.hbs
+++ b/app/templates/components/gist-header.hbs
@@ -37,7 +37,7 @@
                   downloadProject=(route-action "downloadProject")
       }}
 
-      {{editor-mode-menu setKeyMap=(action this.attrs.setEditorKeyMap)}}
+      {{editor-mode-menu selectedKeyMap=selectedKeyMap setKeyMap=(action this.attrs.setEditorKeyMap)}}
 
       {{versions-menu versionSelected=(action this.attrs.versionSelected)
                       emberVersions=emberVersions

--- a/app/templates/components/main-gist.hbs
+++ b/app/templates/components/main-gist.hbs
@@ -4,6 +4,7 @@
               activeEditorCol=activeEditorCol
               activeFile=activeFile
               isRevision=isRevision
+              selectedKeyMap=settings.keyMap
               titleChanged=(action "titleChanged")
               addFile=(action "addFile")
               addHelper=(action "addHelper")

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,7 +40,8 @@ module.exports = function(defaults) {
     },
     codemirror: {
       modes: ['xml', 'javascript', 'handlebars', 'htmlmixed', 'css'],
-      keyMaps: ['emacs', 'sublime', 'vim']
+      keyMaps: ['emacs', 'sublime', 'vim'],
+      addonFiles: ['comment/comment.js']
     },
     'ember-cli-bootstrap-sassy': {
       'js': ['dropdown', 'collapse']

--- a/tests/acceptance/code-comment-test.js
+++ b/tests/acceptance/code-comment-test.js
@@ -20,23 +20,34 @@ test('checks javascript comment option', async function(assert) {
 
 
   await runGist(files);
-  await click('.CodeMirror-code');
 
-  let [firstNode] = find('.cm-property');
+  let textboxNode = 'textarea:eq(1)';
+  textboxNode = '.CodeMirror textarea';
+  await click(textboxNode);
 
-  await triggerEvent(firstNode, 'keypress', {
-    keyCode: '65', // 'A'
+  await triggerEvent(textboxNode, 'keydown', {
+    keyCode: 65, // 'A'
     metaKey: true
   });
 
-  await triggerEvent(firstNode, 'keypress', {
-    keyCode: '191',   // '/'
+  await triggerEvent(textboxNode, 'keydown', {
+    keyCode: 191, // '/'
     metaKey: true
   });
 
   let [firstLine] = find('.CodeMirror-line');
-
   let content = firstLine.textContent;
 
   assert.ok(content.startsWith('//'), 'Line has been commented');
+
+  await triggerEvent(textboxNode, 'keydown', {
+    keyCode: 191, // '/'
+    metaKey: true
+  });
+
+  [firstLine] = find('.CodeMirror-line');
+  content = firstLine.textContent;
+
+  assert.notOk(content.startsWith('//'), 'Line has been uncommented');
+
 });

--- a/tests/acceptance/code-comment-test.js
+++ b/tests/acceptance/code-comment-test.js
@@ -1,0 +1,42 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'ember-twiddle/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | code comment');
+
+test('checks javascript comment option', async function(assert) {
+  const files = [
+    {
+      filename: "application.controller.js",
+      content: `import Ember from "ember";
+                export default Ember.Controller.extend({
+                  appName: 'Ember Twiddle'
+                });`
+    },
+    {
+      filename: "application.template.hbs",
+      content: "Welcome to {{appName}}"
+    }
+  ];
+
+
+  await runGist(files);
+  await click('.CodeMirror-code');
+
+  let [firstNode] = find('.cm-property');
+
+  await triggerEvent(firstNode, 'keypress', {
+    keyCode: '65', // 'A'
+    metaKey: true
+  });
+
+  await triggerEvent(firstNode, 'keypress', {
+    keyCode: '191',   // '/'
+    metaKey: true
+  });
+
+  let [firstLine] = find('.CodeMirror-line');
+
+  let content = firstLine.textContent;
+
+  assert.ok(content.startsWith('//'), 'Line has been commented');
+});

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -3,6 +3,6 @@ import { run } from '@ember/runloop';
 export default function destroyApp(application) {
   run(() => {
     application.destroy();
-    window.server.shutdown();
+    window.server && window.server.shutdown();
   });
 }

--- a/tests/unit/initializers/app-initializer-test.js
+++ b/tests/unit/initializers/app-initializer-test.js
@@ -1,0 +1,26 @@
+import Application from '@ember/application';
+import { run } from '@ember/runloop';
+
+import { initialize } from 'ember-twiddle/initializers/app-initializer';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Initializer | app initializer', {
+  beforeEach() {
+    run(() => {
+      this.application = Application.create();
+      this.application.deferReadiness();
+    });
+  },
+  afterEach() {
+    destroyApp(this.application);
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(this.application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});


### PR DESCRIPTION
- Adds shortcut option to comment javascript code.
  - `cmd-/` in sublime mode (codemirror default)
  - `alt-;` in emac mode (codemirror default)
  - `cmd-/` in default mode ([added in app](https://github.com/ember-cli/ember-twiddle/compare/master...gokatz:code-comment?expand=1#diff-2de9eda1655d499e934e7465e87ca0bdR6))
- Displays selected keystore type

w.r.t. handlebars, maintainer [just added meta data](https://github.com/codemirror/CodeMirror/commit/fbc002f2ba234b91417e086ff1cae0407320c158) to support commenting in handlebar extensions (not released). We can pull once `ivy-codemirror` updates the deps. 

Haven't implemented any tests for the change. Stuck with dynamic rendering of gist in test. Any help will be great.

related to #143 