### PR TITLE
Use Docker to run Gatekeeper

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": "https://registry.bower.io"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# Ignore submodule
+gatekeeper

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gatekeeper"]
+	path = gatekeeper
+	url = https://github.com/prose/gatekeeper.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ You will need the following things properly installed on your computer.
 
 ### Running / Development With Docker (OPTIONAL)
 
+Docker has been setup to make things easier to get setup and working.
+
 #### Additional Dependencies
 
 * [Docker](https://docs.docker.com/install/) (Optional)
@@ -55,9 +57,26 @@ You will need the following things properly installed on your computer.
 
 #### Instructions
 
-* `node index.js` from your gatekeeper folder
-* `docker-compose up` from ember twiddle folder
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+First thing you want to do is edit the `docker-compose.yml`
+file and change the `CHANGEME` to match your keys and secrets.
+Then you will want to run the following commands:
+
+``` bash
+# Pull gatekeeper code
+$ git submodule init
+$ git submodule update
+
+# Start Docker
+$ docker-compose up
+
+# When you are done coding, to stop the container, hit Ctrl+C
+$ docker-compose stop
+
+# When you want to start again
+$ docker-compose start
+```
+
+Visit the app at [http://localhost:4200](http://localhost:4200).
 
 ### Code Generators
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ember:
-    image: danlynn/ember-cli:2.11.1
+    image: danlynn/ember-cli:2.16.2-node_8.7
     container_name: ember-twiddle
     ports:
       - 4200:4200
@@ -10,10 +10,24 @@ services:
     volumes:
       - .:/myapp
       - ./entrypoint.sh:/entrypoint.sh
-      - /app/bower_components
-      - /app/node_modules
-      - /app/tmp
-      - /app/dist
+      - /myapp/bower_components
+      - /myapp/node_modules
+      - /myapp/dist
+    tmpfs:
+      - /myapp/tmp
     environment:
       - GH_API_KEY=CHANGEME
     command: ["sh", "/entrypoint.sh"]
+  gatekeeper:
+    image: node:6.11.1-alpine
+    container_name: gatekeeper-twiddle
+    working_dir: /home/node/app
+    environment:
+      - NODE_ENV=production
+      - OAUTH_CLIENT_ID=CHANGEME
+      - OAUTH_CLIENT_SECRET=CHANGEME
+    volumes:
+      - ./gatekeeper:/home/node/app
+    ports:
+      - 9999:9999
+    command: /bin/sh -c "yarn && npm run start"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# Installing yarn
-npm install -g yarn
-
 # Install the project dependencies
-yarn
-bower install --allow-root
+bower install --allow-root & wait
+yarn & wait
 
 ember server


### PR DESCRIPTION
Instead of having to setup Gatekeeper separately, we can use Docker to help us