### PR TITLE
Fix ember-cli service babelOpts config bug

### DIFF
--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -526,7 +526,7 @@ function babelOpts(moduleName) {
       }],
       'transform-decorators-legacy',
       'transform-class-properties',
-      "transform-object-rest-spread",
+      'transform-object-rest-spread',
       hbsPlugin,
       newModulesPlugin
     ]

--- a/app/services/ember-cli.js
+++ b/app/services/ember-cli.js
@@ -526,6 +526,7 @@ function babelOpts(moduleName) {
       }],
       'transform-decorators-legacy',
       'transform-class-properties',
+      "transform-object-rest-spread",
       hbsPlugin,
       newModulesPlugin
     ]


### PR DESCRIPTION
Include 'transform-object-rest-spread' plugin to fix ES6 object
spread bug.