### PR TITLE
fix broken switch test function

### DIFF
--- a/app/components/main-gist.js
+++ b/app/components/main-gist.js
@@ -260,8 +260,6 @@ export default Component.extend(AppBuilderMixin, ColumnsMixin, FilesMixin, TestF
 
     switchTests(testsEnabled) {
       this.ensureTestHelperExists();
-      this.ensureTestStartAppHelperExists();
-      this.ensureTestDestroyAppHelperExists();
 
       this.emberCli.setTesting(this.model, testsEnabled);
       this.rebuildApp.perform();


### PR DESCRIPTION
When toggling `Run Tests`, we are getting the below console error:
<img width="440" alt="Screen Shot 2020-10-06 at 9 22 50 pm" src="https://user-images.githubusercontent.com/1572901/95189873-32d62900-081a-11eb-925a-bc18c22cf8c8.png">

On investigation, I found that `ensureTestStartAppHelperExists` and `ensureTestDestroyAppHelperExists` functions have been removed in this PR: https://github.com/ember-cli/ember-twiddle/pull/702/files#diff-ce45d0a320c9223a3cd12a5591a6584cL8-L19

This PR is to just remove the use of those two functions in the `switchTest` function as it's currently breaking this feature at the moment.
